### PR TITLE
Orphanet benchmark

### DIFF
--- a/config/OrphaNet/data.tsv
+++ b/config/OrphaNet/data.tsv
@@ -1,0 +1,2787 @@
+Disease_Curie	Disease_Name	Gene_Curie	Gene_Name
+ORPHANET:166024	Multiple epiphyseal dysplasia, Al-Gazali type	ENSEMBL:ENSG00000166813	kinesin family member 7
+ORPHANET:93	Aspartylglucosaminuria	ENSEMBL:ENSG00000038002	aspartylglucosaminidase
+ORPHANET:166035	Brachydactyly-short stature-retinitis pigmentosa syndrome	ENSEMBL:ENSG00000153015	CWC27 spliceosome associated cyclophilin
+ORPHANET:585	Multiple sulfatase deficiency	ENSEMBL:ENSG00000144455	sulfatase modifying factor 1
+ORPHANET:118	Beta-mannosidosis	ENSEMBL:ENSG00000109323	mannosidase beta
+ORPHANET:166063	Pontocerebellar hypoplasia type 4	ENSEMBL:ENSG00000182173	tRNA splicing endonuclease subunit 54
+ORPHANET:166078	Von Willebrand disease type 1	ENSEMBL:ENSG00000110799	von Willebrand factor
+ORPHANET:166073	Pontocerebellar hypoplasia type 6	ENSEMBL:ENSG00000146282	arginyl-tRNA synthetase 2, mitochondrial
+ORPHANET:166084	Von Willebrand disease type 2A	ENSEMBL:ENSG00000110799	von Willebrand factor
+ORPHANET:333	Farber disease	ENSEMBL:ENSG00000104763	N-acylsphingosine amidohydrolase 1
+ORPHANET:349	Fucosidosis	ENSEMBL:ENSG00000179163	alpha-L-fucosidase 1
+ORPHANET:166090	Von Willebrand disease type 2M	ENSEMBL:ENSG00000110799	von Willebrand factor
+ORPHANET:166087	Von Willebrand disease type 2B	ENSEMBL:ENSG00000110799	von Willebrand factor
+ORPHANET:366	Glycogen storage disease due to glycogen debranching enzyme deficiency	ENSEMBL:ENSG00000162688	amylo-alpha-1, 6-glucosidase, 4-alpha-glucanotransferase
+ORPHANET:166093	Von Willebrand disease type 2N	ENSEMBL:ENSG00000110799	von Willebrand factor
+ORPHANET:368	Glycogen storage disease due to muscle glycogen phosphorylase deficiency	ENSEMBL:ENSG00000068976	glycogen phosphorylase, muscle associated
+ORPHANET:166096	Von Willebrand disease type 3	ENSEMBL:ENSG00000110799	von Willebrand factor
+ORPHANET:371	Glycogen storage disease due to muscle phosphofructokinase deficiency	ENSEMBL:ENSG00000152556	phosphofructokinase, muscle
+ORPHANET:166105	FASTKD2-related infantile mitochondrial encephalomyopathy	ENSEMBL:ENSG00000118246	FAST kinase domains 2
+ORPHANET:369	Glycogen storage disease due to liver glycogen phosphorylase deficiency	ENSEMBL:ENSG00000100504	glycogen phosphorylase L
+ORPHANET:447	Paroxysmal nocturnal hemoglobinuria	ENSEMBL:ENSG00000165195	phosphatidylinositol glycan anchor biosynthesis class A
+ORPHANET:166108	Intellectual disability, Birk-Barel type	ENSEMBL:ENSG00000169427	potassium two pore domain channel subfamily K member 9
+ORPHANET:166119	Isolated osteopoikilosis	ENSEMBL:ENSG00000174106	LEM domain containing 3
+ORPHANET:166260	Dentinogenesis imperfecta type 2	ENSEMBL:ENSG00000152591	dentin sialophosphoprotein
+ORPHANET:166265	Dentinogenesis imperfecta type 3	ENSEMBL:ENSG00000152591	dentin sialophosphoprotein
+ORPHANET:166272	Odontochondrodysplasia	ENSEMBL:ENSG00000100815	thyroid hormone receptor interactor 11
+ORPHANET:576	Mucolipidosis type II	ENSEMBL:ENSG00000111670	N-acetylglucosamine-1-phosphate transferase subunits alpha and beta
+ORPHANET:812	Sialidosis type 1	ENSEMBL:ENSG00000204386	neuraminidase 1
+ORPHANET:578	Mucolipidosis type IV	ENSEMBL:ENSG00000090674	mucolipin TRP cation channel 1
+ORPHANET:166286	Porokeratotic eccrine ostial and dermal duct nevus	ENSEMBL:ENSG00000165474	gap junction protein beta 2
+ORPHANET:584	Mucopolysaccharidosis type 7	ENSEMBL:ENSG00000169919	glucuronidase beta
+ORPHANET:825	NON RARE IN EUROPE: Ankylosing spondylitis	ENSEMBL:ENSG00000234745	major histocompatibility complex, class I, B
+ORPHANET:166412	Hot water reflex epilepsy	ENSEMBL:ENSG00000106688	solute carrier family 1 member 1
+ORPHANET:95	Friedreich ataxia	ENSEMBL:ENSG00000165060	frataxin
+ORPHANET:597	Central core disease	ENSEMBL:ENSG00000196218	ryanodine receptor 1
+ORPHANET:163746	Peripheral demyelinating neuropathy-central dysmyelinating leukodystrophy-Waardenburg syndrome-Hirschsprung disease	ENSEMBL:ENSG00000100146	SRY-box transcription factor 10
+ORPHANET:684	Paramyotonia congenita of Von Eulenburg	ENSEMBL:ENSG00000007314	sodium voltage-gated channel alpha subunit 4
+ORPHANET:163937	X-linked intellectual disability, Najm type	ENSEMBL:ENSG00000147044	calcium/calmodulin dependent serine protein kinase
+ORPHANET:614	Thomsen and Becker disease	ENSEMBL:ENSG00000188037	chloride voltage-gated channel 1
+ORPHANET:163966	X-linked dominant chondrodysplasia, Chassaing-Lacombe type	ENSEMBL:ENSG00000094631	histone deacetylase 6
+ORPHANET:163976	X-linked intellectual disability, Van Esch type	ENSEMBL:ENSG00000101868	DNA polymerase alpha 1, catalytic subunit
+ORPHANET:163956	X-linked intellectual disability, Nascimento type	ENSEMBL:ENSG00000077721	ubiquitin conjugating enzyme E2 A
+ORPHANET:324	Fabry disease	ENSEMBL:ENSG00000102393	galactosidase alpha
+ORPHANET:163985	Hyperekplexia-epilepsy syndrome	ENSEMBL:ENSG00000131089	Cdc42 guanine nucleotide exchange factor 9
+ORPHANET:778	Rett syndrome	ENSEMBL:ENSG00000169057	methyl-CpG binding protein 2
+ORPHANET:1941	Juvenile absence epilepsy	ENSEMBL:ENSG00000096093	EF-hand domain containing 1
+ORPHANET:165805	Familial mesial temporal lobe epilepsy with febrile seizures	ENSEMBL:ENSG00000165078	carboxypeptidase A6
+ORPHANET:100	Ataxia-telangiectasia	ENSEMBL:ENSG00000149311	ATM serine/threonine kinase
+ORPHANET:166011	Multiple epiphyseal dysplasia, Beighton type	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:232	Sickle cell anemia	ENSEMBL:ENSG00000244734	hemoglobin subunit beta
+ORPHANET:534	Oculocerebrorenal syndrome of Lowe	ENSEMBL:ENSG00000122126	OCRL inositol polyphosphate-5-phosphatase
+ORPHANET:165991	Exercise-induced hyperinsulinism	ENSEMBL:ENSG00000155380	solute carrier family 16 member 1
+ORPHANET:908	Fragile X syndrome	ENSEMBL:ENSG00000102081	fragile X messenger ribonucleoprotein 1
+ORPHANET:47	X-linked agammaglobulinemia	ENSEMBL:ENSG00000010671	Bruton tyrosine kinase
+ORPHANET:905	Wilson disease	ENSEMBL:ENSG00000123191	ATPase copper transporting beta
+ORPHANET:792	X-linked retinoschisis	ENSEMBL:ENSG00000102104	retinoschisin 1
+ORPHANET:15	Achondroplasia	ENSEMBL:ENSG00000068078	fibroblast growth factor receptor 3
+ORPHANET:96	Ataxia with vitamin E deficiency	ENSEMBL:ENSG00000137561	alpha tocopherol transfer protein
+ORPHANET:101	Dentatorubral pallidoluysian atrophy	ENSEMBL:ENSG00000111676	atrophin 1
+ORPHANET:276	T-B+ severe combined immunodeficiency due to gamma chain deficiency	ENSEMBL:ENSG00000147168	interleukin 2 receptor subunit gamma
+ORPHANET:481	Kennedy disease	ENSEMBL:ENSG00000169083	androgen receptor
+ORPHANET:664	Ornithine transcarbamylase deficiency	ENSEMBL:ENSG00000036473	ornithine transcarbamylase
+ORPHANET:394	Classic homocystinuria	ENSEMBL:ENSG00000160200	cystathionine beta-synthase
+ORPHANET:508	Leprechaunism	ENSEMBL:ENSG00000171105	insulin receptor
+ORPHANET:429	Hypochondroplasia	ENSEMBL:ENSG00000068078	fibroblast growth factor receptor 3
+ORPHANET:2182	Hydrocephalus with stenosis of the aqueduct of Sylvius	ENSEMBL:ENSG00000198910	L1 cell adhesion molecule
+ORPHANET:163717	Benign familial mesial temporal lobe epilepsy	ENSEMBL:ENSG00000165078	carboxypeptidase A6
+ORPHANET:649	Norrie disease	ENSEMBL:ENSG00000124479	norrin cystine knot growth factor NDP
+ORPHANET:163727	Rolandic epilepsy-paroxysmal exercise-induced dystonia-writer's cramp syndrome	ENSEMBL:ENSG00000162065	TBC1 domain family member 24
+ORPHANET:163684	Leukoencephalopathy-dystonia-motor neuropathy syndrome	ENSEMBL:ENSG00000116171	sterol carrier protein 2
+ORPHANET:163681	CNTNAP2-related developmental and epileptic encephalopathy	ENSEMBL:ENSG00000174469	contactin associated protein 2
+ORPHANET:644	NARP syndrome	ENSEMBL:ENSG00000198899	mitochondrially encoded ATP synthase membrane subunit 6
+ORPHANET:637	Full NF2-related schwannomatosis	ENSEMBL:ENSG00000186575	NF2, moesin-ezrin-radixin like (MERLIN) tumor suppressor
+ORPHANET:163696	Action myoclonus-renal failure syndrome	ENSEMBL:ENSG00000138760	scavenger receptor class B member 2
+ORPHANET:337	Fibrodysplasia ossificans progressiva	ENSEMBL:ENSG00000115170	activin A receptor type 1
+ORPHANET:752	46,XY disorder of sex development due to 17-beta-hydroxysteroid dehydrogenase 3 deficiency	ENSEMBL:ENSG00000130948	hydroxysteroid 17-beta dehydrogenase 3
+ORPHANET:510	Lesch-Nyhan syndrome	ENSEMBL:ENSG00000165704	hypoxanthine phosphoribosyltransferase 1
+ORPHANET:60	Alpha-1-antitrypsin deficiency	ENSEMBL:ENSG00000197249	serpin family A member 1
+ORPHANET:896	Waardenburg syndrome type 3	ENSEMBL:ENSG00000135903	paired box 3
+ORPHANET:894	Waardenburg syndrome type 1	ENSEMBL:ENSG00000135903	paired box 3
+ORPHANET:682	Hyperkalemic periodic paralysis	ENSEMBL:ENSG00000007314	sodium voltage-gated channel alpha subunit 4
+ORPHANET:800	Schwartz-Jampel syndrome	ENSEMBL:ENSG00000142798	heparan sulfate proteoglycan 2
+ORPHANET:628	Diastrophic dysplasia	ENSEMBL:ENSG00000155850	solute carrier family 26 member 2
+ORPHANET:2869	Peutz-Jeghers syndrome	ENSEMBL:ENSG00000118046	serine/threonine kinase 11
+ORPHANET:53	Albers-Schönberg osteopetrosis	ENSEMBL:ENSG00000103249	chloride voltage-gated channel 7
+ORPHANET:14	Abetalipoproteinemia	ENSEMBL:ENSG00000138823	microsomal triglyceride transfer protein
+ORPHANET:167	Chédiak-Higashi syndrome	ENSEMBL:ENSG00000143669	lysosomal trafficking regulator
+ORPHANET:192	Coffin-Lowry syndrome	ENSEMBL:ENSG00000177189	ribosomal protein S6 kinase A3
+ORPHANET:169808	Mild hemophilia A	ENSEMBL:ENSG00000185010	coagulation factor VIII
+ORPHANET:169802	Severe hemophilia A	ENSEMBL:ENSG00000185010	coagulation factor VIII
+ORPHANET:169805	Moderate hemophilia A	ENSEMBL:ENSG00000185010	coagulation factor VIII
+ORPHANET:562	McCune-Albright syndrome	ENSEMBL:ENSG00000087460	GNAS complex locus
+ORPHANET:565	Menkes disease	ENSEMBL:ENSG00000165240	ATPase copper transporting alpha
+ORPHANET:258	Laminin subunit alpha 2-related congenital muscular dystrophy	ENSEMBL:ENSG00000196569	laminin subunit alpha 2
+ORPHANET:169464	Primary CD59 deficiency	ENSEMBL:ENSG00000085063	CD59 molecule (CD59 blood group)
+ORPHANET:87	Apert syndrome	ENSEMBL:ENSG00000066468	fibroblast growth factor receptor 2
+ORPHANET:97	Familial paroxysmal ataxia	ENSEMBL:ENSG00000141837	calcium voltage-gated channel subunit alpha1 A
+ORPHANET:169467	Recurrent Neisseria infections due to factor D deficiency	ENSEMBL:ENSG00000197766	complement factor D
+ORPHANET:169799	Mild hemophilia B	ENSEMBL:ENSG00000101981	coagulation factor IX
+ORPHANET:169796	Moderate hemophilia B	ENSEMBL:ENSG00000101981	coagulation factor IX
+ORPHANET:169793	Severe hemophilia B	ENSEMBL:ENSG00000101981	coagulation factor IX
+ORPHANET:1000	Ocular albinism with late-onset sensorineural deafness	ENSEMBL:ENSG00000065000	adaptor related protein complex 3 subunit delta 1
+ORPHANET:171445	Muscle filaminopathy	ENSEMBL:ENSG00000128591	filamin C
+ORPHANET:1349	Mitochondrial DNA-related cardiomyopathy and hearing loss	ENSEMBL:ENSG00000210156	mitochondrially encoded tRNA-Lys (AAA/G)
+ORPHANET:171629	Autosomal recessive spastic paraplegia type 35	ENSEMBL:ENSG00000103089	fatty acid 2-hydroxylase
+ORPHANET:357	NON RARE IN EUROPE: Gilbert syndrome	ENSEMBL:ENSG00000241635	UDP glucuronosyltransferase family 1 member A1
+ORPHANET:1727	22q11.2 duplication syndrome	ENSEMBL:ENSG00000184058	T-box transcription factor 1
+ORPHANET:169079	Cernunnos-XLF deficiency	ENSEMBL:ENSG00000187736	non-homologous end joining factor 1
+ORPHANET:169100	Immunodeficiency due to CD25 deficiency	ENSEMBL:ENSG00000134460	interleukin 2 receptor subunit alpha
+ORPHANET:169095	Severe combined immunodeficiency due to FOXN1 deficiency	ENSEMBL:ENSG00000109101	forkhead box N1
+ORPHANET:169082	Combined immunodeficiency due to CD3gamma deficiency	ENSEMBL:ENSG00000160654	CD3 gamma subunit of T-cell receptor complex
+ORPHANET:169085	Susceptibility to respiratory infections associated with CD8alpha chain mutation	ENSEMBL:ENSG00000153563	CD8a molecule
+ORPHANET:168829	Primary peritoneal carcinoma	ENSEMBL:ENSG00000012048	BRCA1 DNA repair associated
+ORPHANET:753	46,XY disorder of sex development due to 5-alpha-reductase 2 deficiency	ENSEMBL:ENSG00000277893	steroid 5 alpha-reductase 2
+ORPHANET:868	Triose phosphate-isomerase deficiency	ENSEMBL:ENSG00000111669	triosephosphate isomerase 1
+ORPHANET:218	Darier disease	ENSEMBL:ENSG00000174437	ATPase sarcoplasmic/endoplasmic reticulum Ca2+ transporting 2
+ORPHANET:168796	Heart-hand syndrome, Slovenian type	ENSEMBL:ENSG00000160789	lamin A/C
+ORPHANET:168953	Myeloid/lymphoid neoplasm associated with FGFR1 rearrangement	ENSEMBL:ENSG00000077782	fibroblast growth factor receptor 1
+ORPHANET:168950	Myeloid/lymphoid neoplasm associated with PDGFRB rearrangement	ENSEMBL:ENSG00000113721	platelet derived growth factor receptor beta
+ORPHANET:168947	Myeloid/lymphoid neoplasm associated with PDGFRA rearrangement	ENSEMBL:ENSG00000134853	platelet derived growth factor receptor alpha
+ORPHANET:169154	T-B+ severe combined immunodeficiency due to IL-7Ralpha deficiency	ENSEMBL:ENSG00000168685	interleukin 7 receptor
+ORPHANET:169157	T-B+ severe combined immunodeficiency due to CD45 deficiency	ENSEMBL:ENSG00000081237	protein tyrosine phosphatase receptor type C
+ORPHANET:1947	Progressive epilepsy-intellectual disability syndrome, Finnish type	ENSEMBL:ENSG00000182372	CLN8 transmembrane ER and ERGIC protein
+ORPHANET:596	X-linked centronuclear myopathy	ENSEMBL:ENSG00000171100	myotubularin 1
+ORPHANET:464	Incontinentia pigmenti	ENSEMBL:ENSG00000269335	inhibitor of nuclear factor kappa B kinase regulatory subunit gamma
+ORPHANET:56	Alkaptonuria	ENSEMBL:ENSG00000113924	homogentisate 1,2-dioxygenase
+ORPHANET:1059	Blue rubber bleb nevus	ENSEMBL:ENSG00000120156	TEK receptor tyrosine kinase
+ORPHANET:22	Succinic semialdehyde dehydrogenase deficiency	ENSEMBL:ENSG00000112294	aldehyde dehydrogenase 5 family member A1
+ORPHANET:29	Mevalonic aciduria	ENSEMBL:ENSG00000110921	mevalonate kinase
+ORPHANET:245	Nager syndrome	ENSEMBL:ENSG00000143368	splicing factor 3b subunit 4
+ORPHANET:30	Hereditary orotic aciduria	ENSEMBL:ENSG00000114491	uridine monophosphate synthetase
+ORPHANET:915	Aarskog-Scott syndrome	ENSEMBL:ENSG00000102302	FYVE, RhoGEF and PH domain containing 1
+ORPHANET:2614	Nail-patella syndrome	ENSEMBL:ENSG00000136944	LIM homeobox transcription factor 1 beta
+ORPHANET:33	Isovaleric acidemia	ENSEMBL:ENSG00000128928	isovaleryl-CoA dehydrogenase
+ORPHANET:168615	Hereditary persistence of alpha-fetoprotein	ENSEMBL:ENSG00000081051	alpha fetoprotein
+ORPHANET:168612	Congenital deficiency in alpha-fetoprotein	ENSEMBL:ENSG00000081051	alpha fetoprotein
+ORPHANET:1452	Cleidocranial dysplasia	ENSEMBL:ENSG00000124813	RUNX family transcription factor 2
+ORPHANET:168624	Familial scaphocephaly syndrome, McGillivray type	ENSEMBL:ENSG00000066468	fibroblast growth factor receptor 2
+ORPHANET:193	Cohen syndrome	ENSEMBL:ENSG00000132549	vacuolar protein sorting 13 homolog B
+ORPHANET:168583	Hereditary North American Indian childhood cirrhosis	ENSEMBL:ENSG00000141076	UTP4 small subunit processome component
+ORPHANET:168577	Hereditary cryohydrocytosis with reduced stomatin	ENSEMBL:ENSG00000117394	solute carrier family 2 member 1
+ORPHANET:168593	Sudden infant death-dysgenesis of the testes syndrome	ENSEMBL:ENSG00000189241	TSPY like 1
+ORPHANET:168601	Congenital enteropathy due to enteropeptidase deficiency	ENSEMBL:ENSG00000154646	transmembrane serine protease 15
+ORPHANET:168598	Brain demyelination due to methionine adenosyltransferase deficiency	ENSEMBL:ENSG00000151224	methionine adenosyltransferase 1A
+ORPHANET:168606	Seborrhea-like dermatitis with psoriasiform elements	ENSEMBL:ENSG00000141579	zinc finger protein 750
+ORPHANET:1154	Arthrogryposis-oculomotor limitation-electroretinal anomalies syndrome	ENSEMBL:ENSG00000154864	piezo type mechanosensitive ion channel component 2
+ORPHANET:168558	46,XY disorder of sex development-adrenal insufficiency due to CYP11A1 deficiency	ENSEMBL:ENSG00000140459	cytochrome P450 family 11 subfamily A member 1
+ORPHANET:168563	46,XY gonadal dysgenesis-motor and sensory neuropathy syndrome	ENSEMBL:ENSG00000139549	desert hedgehog signaling molecule
+ORPHANET:168566	Fatal mitochondrial disease due to combined oxidative phosphorylation defect type 3	ENSEMBL:ENSG00000123297	Ts translation elongation factor, mitochondrial
+ORPHANET:1310	Caffey disease	ENSEMBL:ENSG00000108821	collagen type I alpha 1 chain
+ORPHANET:168569	H syndrome	ENSEMBL:ENSG00000198246	solute carrier family 29 member 3
+ORPHANET:168572	Native American myopathy	ENSEMBL:ENSG00000185482	SH3 and cysteine rich domain 3
+ORPHANET:125	Bloom syndrome	ENSEMBL:ENSG00000197299	BLM RecQ like helicase
+ORPHANET:90	Argininemia	ENSEMBL:ENSG00000118520	arginase 1
+ORPHANET:168454	Spondyloepimetaphyseal dysplasia, Geneviève type	ENSEMBL:ENSG00000095380	N-acetylneuraminate synthase
+ORPHANET:246	Postaxial acrofacial dysostosis	ENSEMBL:ENSG00000102967	dihydroorotate dehydrogenase (quinone)
+ORPHANET:1764	Familial dysautonomia	ENSEMBL:ENSG00000070061	elongator complex protein 1
+ORPHANET:239	Dyggve-Melchior-Clausen disease	ENSEMBL:ENSG00000141627	dymeclin
+ORPHANET:395	Homocystinuria due to methylene tetrahydrofolate reductase deficiency	ENSEMBL:ENSG00000177000	methylenetetrahydrofolate reductase
+ORPHANET:147	Carbamoyl-phosphate synthetase 1 deficiency	ENSEMBL:ENSG00000021826	carbamoyl-phosphate synthase 1
+ORPHANET:23	Argininosuccinic aciduria	ENSEMBL:ENSG00000126522	argininosuccinate lyase
+ORPHANET:226	Dihydropteridine reductase deficiency	ENSEMBL:ENSG00000151552	quinoid dihydropteridine reductase
+ORPHANET:1496	Corpus callosum agenesis-neuronopathy syndrome	ENSEMBL:ENSG00000140199	solute carrier family 12 member 6
+ORPHANET:2118	Hawkinsinuria	ENSEMBL:ENSG00000158104	4-hydroxyphenylpyruvate dioxygenase
+ORPHANET:351	Galactosialidosis	ENSEMBL:ENSG00000064601	cathepsin A
+ORPHANET:1933	Mitochondrial DNA depletion syndrome, encephalomyopathic form with methylmalonic aciduria	ENSEMBL:ENSG00000136143	succinate-CoA ligase ADP-forming subunit beta
+ORPHANET:1880	Ebstein malformation of the tricuspid valve	ENSEMBL:ENSG00000092054	myosin heavy chain 7
+ORPHANET:2635	Metatropic dysplasia	ENSEMBL:ENSG00000111199	transient receptor potential cation channel subfamily V member 4
+ORPHANET:606	Proximal myotonic myopathy	ENSEMBL:ENSG00000169714	CCHC-type zinc finger nucleic acid binding protein
+ORPHANET:2785	Osteopetrosis with renal tubular acidosis	ENSEMBL:ENSG00000104267	carbonic anhydrase 2
+ORPHANET:2746	Opsismodysplasia	ENSEMBL:ENSG00000165458	inositol polyphosphate phosphatase like 1
+ORPHANET:2971	Peroxisomal acyl-CoA oxidase deficiency	ENSEMBL:ENSG00000161533	acyl-CoA oxidase 1
+ORPHANET:2970	Prune belly syndrome	ENSEMBL:ENSG00000133019	cholinergic receptor muscarinic 3
+ORPHANET:2903	Familial spontaneous pneumothorax	ENSEMBL:ENSG00000154803	folliculin
+ORPHANET:2901	Neuralgic amyotrophy	ENSEMBL:ENSG00000184640	septin 9
+ORPHANET:718	Isolated Pierre Robin syndrome	ENSEMBL:ENSG00000125398	SRY-box transcription factor 9
+ORPHANET:3071	Costello syndrome	ENSEMBL:ENSG00000174775	HRas proto-oncogene, GTPase
+ORPHANET:763	Pycnodysostosis	ENSEMBL:ENSG00000143387	cathepsin K
+ORPHANET:469	Hereditary fructose intolerance	ENSEMBL:ENSG00000136872	aldolase, fructose-bisphosphate B
+ORPHANET:2308	Jacobsen syndrome	ENSEMBL:ENSG00000151702	Fli-1 proto-oncogene, ETS transcription factor
+ORPHANET:2253	Foveal hypoplasia-presenile cataract syndrome	ENSEMBL:ENSG00000007372	paired box 6
+ORPHANET:180188	Isolated congenital breast hypoplasia/aplasia	ENSEMBL:ENSG00000142949	protein tyrosine phosphatase receptor type F
+ORPHANET:2300	Multiple intestinal atresia	ENSEMBL:ENSG00000068724	tetratricopeptide repeat domain 7A
+ORPHANET:2377	Laurence-Moon syndrome	ENSEMBL:ENSG00000032444	patatin like phospholipase domain containing 6
+ORPHANET:2466	MASA syndrome	ENSEMBL:ENSG00000198910	L1 cell adhesion molecule
+ORPHANET:560	Marshall syndrome	ENSEMBL:ENSG00000060718	collagen type XI alpha 1 chain
+ORPHANET:179494	Obesity due to leptin receptor gene deficiency	ENSEMBL:ENSG00000116678	leptin receptor
+ORPHANET:816	Sjögren-Larsson syndrome	ENSEMBL:ENSG00000072210	aldehyde dehydrogenase 3 family member A2
+ORPHANET:3205	Sturge-Weber syndrome	ENSEMBL:ENSG00000156052	G protein subunit alpha q
+ORPHANET:3320	Thrombocytopenia-absent radius syndrome	ENSEMBL:ENSG00000265241	RNA binding motif protein 8A
+ORPHANET:887	VACTERL/VATER association	ENSEMBL:ENSG00000128714	homeobox D13
+ORPHANET:909	Cerebrotendinous xanthomatosis	ENSEMBL:ENSG00000135929	cytochrome P450 family 27 subfamily A member 1
+ORPHANET:1422	Chondrodysplasia-disorder of sex development syndrome	ENSEMBL:ENSG00000054392	hedgehog acyltransferase
+ORPHANET:178461	X-linked myopathy with postural muscle atrophy	ENSEMBL:ENSG00000022267	four and a half LIM domains 1
+ORPHANET:178464	Hereditary myopathy with early respiratory failure	ENSEMBL:ENSG00000155657	titin
+ORPHANET:178396	Hemorrhagic disease due to alpha-1-antitrypsin Pittsburgh mutation	ENSEMBL:ENSG00000197249	serpin family A member 1
+ORPHANET:178400	Distal myopathy with anterior tibial onset	ENSEMBL:ENSG00000135636	dysferlin
+ORPHANET:178389	Osteopetrosis-hypogammaglobulinemia syndrome	ENSEMBL:ENSG00000141655	TNF receptor superfamily member 11a
+ORPHANET:62	Alpha-sarcoglycan-related limb-girdle muscular dystrophy R3	ENSEMBL:ENSG00000108823	sarcoglycan alpha
+ORPHANET:178364	Syndromic microphthalmia type 5	ENSEMBL:ENSG00000165588	orthodenticle homeobox 2
+ORPHANET:178377	Osteosclerosis-developmental delay-craniosynostosis syndrome	ENSEMBL:ENSG00000162337	LDL receptor related protein 5
+ORPHANET:348	Fructose-1,6-bisphosphatase deficiency	ENSEMBL:ENSG00000165140	fructose-bisphosphatase 1
+ORPHANET:178345	Aromatase excess syndrome	ENSEMBL:ENSG00000137869	cytochrome P450 family 19 subfamily A member 1
+ORPHANET:178509	Perry syndrome	ENSEMBL:ENSG00000204843	dynactin subunit 1
+ORPHANET:178506	Brain calcification, Rajab type	ENSEMBL:ENSG00000116120	phenylalanyl-tRNA synthetase subunit beta
+ORPHANET:177926	Bleeding disorder in hemophilia A carriers	ENSEMBL:ENSG00000185010	coagulation factor VIII
+ORPHANET:177929	Bleeding disorder in hemophilia B carriers	ENSEMBL:ENSG00000101981	coagulation factor IX
+ORPHANET:177907	Prader-Willi syndrome due to translocation	ENSEMBL:ENSG00000128739	small nuclear ribonucleoprotein polypeptide N
+ORPHANET:178333	Åland Islands eye disease	ENSEMBL:ENSG00000102001	calcium voltage-gated channel subunit alpha1 F
+ORPHANET:362	NON RARE IN EUROPE: Glucose-6-phosphate-dehydrogenase deficiency	ENSEMBL:ENSG00000160211	glucose-6-phosphate dehydrogenase
+ORPHANET:760	Purine nucleoside phosphorylase deficiency	ENSEMBL:ENSG00000198805	purine nucleoside phosphorylase
+ORPHANET:270	Oculopharyngeal muscular dystrophy	ENSEMBL:ENSG00000100836	poly(A) binding protein nuclear 1
+ORPHANET:178307	Reticulate acropigmentation of Kitamura	ENSEMBL:ENSG00000137845	ADAM metallopeptidase domain 10
+ORPHANET:178145	Moderate multiminicore disease with hand involvement	ENSEMBL:ENSG00000196218	ryanodine receptor 1
+ORPHANET:713	Glycogen storage disease due to phosphoglycerate kinase 1 deficiency	ENSEMBL:ENSG00000102144	phosphoglycerate kinase 1
+ORPHANET:57	Glycogen storage disease due to aldolase A deficiency	ENSEMBL:ENSG00000149925	aldolase, fructose-bisphosphate A
+ORPHANET:2334	Autosomal dominant keratitis	ENSEMBL:ENSG00000007372	paired box 6
+ORPHANET:46	Adenylosuccinate lyase deficiency	ENSEMBL:ENSG00000239900	adenylosuccinate lyase
+ORPHANET:3166	Sialuria	ENSEMBL:ENSG00000159921	glucosamine (UDP-N-acetyl)-2-epimerase/N-acetylmannosamine kinase
+ORPHANET:134	Beta-ketothiolase deficiency	ENSEMBL:ENSG00000075239	acetyl-CoA acetyltransferase 1
+ORPHANET:171706	Short stature-delayed bone age due to thyroid hormone metabolism deficiency	ENSEMBL:ENSG00000187742	SECIS binding protein 2
+ORPHANET:171680	Lissencephaly due to TUBA1A mutation	ENSEMBL:ENSG00000167552	tubulin alpha 1a
+ORPHANET:171690	Metabolic myopathy due to lactate transporter defect	ENSEMBL:ENSG00000155380	solute carrier family 16 member 1
+ORPHANET:171863	Autosomal dominant spastic paraplegia type 42	ENSEMBL:ENSG00000169359	solute carrier family 33 member 1
+ORPHANET:171871	Renal pseudohypoaldosteronism type 1	ENSEMBL:ENSG00000151623	nuclear receptor subfamily 3 group C member 2
+ORPHANET:171866	Spondyloepimetaphyseal dysplasia, aggrecan type	ENSEMBL:ENSG00000157766	aggrecan
+ORPHANET:171829	6q16 microdeletion syndrome	ENSEMBL:ENSG00000112246	SIM bHLH transcription factor 1
+ORPHANET:171848	Polyneuropathy-hearing loss-ataxia-retinitis pigmentosa-cataract syndrome	ENSEMBL:ENSG00000100997	abhydrolase domain containing 12, lysophospholipase
+ORPHANET:200418	Immunodeficiency with factor I anomaly	ENSEMBL:ENSG00000205403	complement factor I
+ORPHANET:200421	Immunodeficiency with factor H anomaly	ENSEMBL:ENSG00000000971	complement factor H
+ORPHANET:98	Autosomal recessive spastic ataxia of Charlevoix-Saguenay	ENSEMBL:ENSG00000151835	sacsin molecular chaperone
+ORPHANET:330	Congenital factor XII deficiency	ENSEMBL:ENSG00000131187	coagulation factor XII
+ORPHANET:199340	Muscular dystrophy, Selcen type	ENSEMBL:ENSG00000151929	BAG cochaperone 3
+ORPHANET:199337	Pancreatic insufficiency-anemia-hyperostosis syndrome	ENSEMBL:ENSG00000131055	cytochrome c oxidase subunit 4I2
+ORPHANET:234	Dubin-Johnson syndrome	ENSEMBL:ENSG00000023839	ATP binding cassette subfamily C member 2
+ORPHANET:199348	Thiamine-responsive encephalopathy	ENSEMBL:ENSG00000135917	solute carrier family 19 member 3
+ORPHANET:199343	EAST syndrome	ENSEMBL:ENSG00000177807	potassium inwardly rectifying channel subfamily J member 10
+ORPHANET:199326	Isolated autosomal dominant hypomagnesemia, Glaudemans type	ENSEMBL:ENSG00000111262	potassium voltage-gated channel subfamily A member 1
+ORPHANET:199332	Endocrine-cerebro-osteodysplasia syndrome	ENSEMBL:ENSG00000112144	ciliogenesis associated kinase 1
+ORPHANET:199329	Congenital myopathy, Paradas type	ENSEMBL:ENSG00000135636	dysferlin
+ORPHANET:199354	Cerebral autosomal recessive arteriopathy-subcortical infarcts-leukoencephalopathy	ENSEMBL:ENSG00000166033	HtrA serine peptidase 1
+ORPHANET:199351	Adult-onset dystonia-parkinsonism	ENSEMBL:ENSG00000184381	phospholipase A2 group VI
+ORPHANET:356	Gerstmann-Straussler-Scheinker syndrome	ENSEMBL:ENSG00000171867	prion protein
+ORPHANET:466	Fatal familial insomnia	ENSEMBL:ENSG00000171867	prion protein
+ORPHANET:3452	Whipple disease	ENSEMBL:ENSG00000137265	interferon regulatory factor 4
+ORPHANET:199285	Hereditary hypercarotenemia and vitamin A deficiency	ENSEMBL:ENSG00000135697	beta-carotene oxygenase 1
+ORPHANET:2102	GTP cyclohydrolase I deficiency	ENSEMBL:ENSG00000131979	GTP cyclohydrolase 1
+ORPHANET:3002	Immune thrombocytopenia	ENSEMBL:ENSG00000244682	Fc gamma receptor IIc (gene/pseudogene)
+ORPHANET:199318	15q13.3 microdeletion syndrome	ENSEMBL:ENSG00000175344	cholinergic receptor nicotinic alpha 7 subunit
+ORPHANET:1195	Congenital atransferrinemia	ENSEMBL:ENSG00000091513	transferrin
+ORPHANET:926	Acatalasemia	ENSEMBL:ENSG00000121691	catalase
+ORPHANET:199296	Congenital isolated ACTH deficiency	ENSEMBL:ENSG00000143178	T-box transcription factor 19
+ORPHANET:1675	Dihydropyrimidine dehydrogenase deficiency	ENSEMBL:ENSG00000188641	dihydropyrimidine dehydrogenase
+ORPHANET:976	Adenine phosphoribosyltransferase deficiency	ENSEMBL:ENSG00000198931	adenine phosphoribosyltransferase
+ORPHANET:3129	Sarcosinemia	ENSEMBL:ENSG00000123453	sarcosine dehydrogenase
+ORPHANET:415	Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome	ENSEMBL:ENSG00000102743	solute carrier family 25 member 15
+ORPHANET:13	6-pyruvoyl-tetrahydropterin synthase deficiency	ENSEMBL:ENSG00000150787	6-pyruvoyltetrahydropterin synthase
+ORPHANET:199247	Corticosteroid-binding globulin deficiency	ENSEMBL:ENSG00000170099	serpin family A member 6
+ORPHANET:199241	Pulmonary capillary hemangiomatosis	ENSEMBL:ENSG00000128829	eukaryotic translation initiation factor 2 alpha kinase 4
+ORPHANET:17	Fatal infantile lactic acidosis with methylmalonic aciduria	ENSEMBL:ENSG00000163541	succinate-CoA ligase GDP/ADP-forming subunit alpha
+ORPHANET:267	Calpain-3-related limb-girdle muscular dystrophy R1	ENSEMBL:ENSG00000092529	calpain 3
+ORPHANET:1136	Arnold-Chiari malformation type II	ENSEMBL:ENSG00000010361	fuzzy planar cell polarity protein
+ORPHANET:2398	Multiple symmetric lipomatosis	ENSEMBL:ENSG00000116688	mitofusin 2
+ORPHANET:2587	Myeloperoxidase deficiency	ENSEMBL:ENSG00000005381	myeloperoxidase
+ORPHANET:3389	Tuberculosis	ENSEMBL:ENSG00000018280	solute carrier family 11 member 1
+ORPHANET:2897	Pityriasis rubra pilaris	ENSEMBL:ENSG00000141527	caspase recruitment domain family member 14
+ORPHANET:2312	Transient familial neonatal hyperbilirubinemia	ENSEMBL:ENSG00000241635	UDP glucuronosyltransferase family 1 member A1
+ORPHANET:183707	Neutrophil immunodeficiency syndrome	ENSEMBL:ENSG00000128340	Rac family small GTPase 2
+ORPHANET:2314	Autosomal dominant hyper-IgE syndrome	ENSEMBL:ENSG00000168610	signal transducer and activator of transcription 3
+ORPHANET:183678	Hermansky-Pudlak syndrome due to AP-3 deficiency	ENSEMBL:ENSG00000132842	adaptor related protein complex 3 subunit beta 1
+ORPHANET:2177	Hydranencephaly	ENSEMBL:ENSG00000072864	nudE neurodevelopment protein 1
+ORPHANET:183713	Bacterial susceptibility due to TLR signaling pathway deficiency	ENSEMBL:ENSG00000172936	MYD88 innate immune signal transduction adaptor
+ORPHANET:2380	Legg-Calvé-Perthes disease	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:643	Giant axonal neuropathy	ENSEMBL:ENSG00000261609	gigaxonin
+ORPHANET:634	Netherton syndrome	ENSEMBL:ENSG00000133710	serine peptidase inhibitor Kazal type 5
+ORPHANET:140	Campomelic dysplasia	ENSEMBL:ENSG00000125398	SRY-box transcription factor 9
+ORPHANET:642	Hereditary sensory and autonomic neuropathy type 4	ENSEMBL:ENSG00000198400	neurotrophic receptor tyrosine kinase 1
+ORPHANET:627	Nance-Horan syndrome	ENSEMBL:ENSG00000188158	NHS actin remodeling regulator
+ORPHANET:326	Congenital factor V deficiency	ENSEMBL:ENSG00000198734	coagulation factor V
+ORPHANET:342	Familial Mediterranean fever	ENSEMBL:ENSG00000103313	MEFV innate immuity regulator, pyrin
+ORPHANET:180	Choroideremia	ENSEMBL:ENSG00000188419	CHM Rab escort protein
+ORPHANET:327	Congenital factor VII deficiency	ENSEMBL:ENSG00000057593	coagulation factor VII
+ORPHANET:847	Alpha-thalassemia-X-linked intellectual disability syndrome	ENSEMBL:ENSG00000085224	ATRX chromatin remodeler
+ORPHANET:392	Holt-Oram syndrome	ENSEMBL:ENSG00000089225	T-box transcription factor 5
+ORPHANET:86	Familial abdominal aortic aneurysm	ENSEMBL:ENSG00000168542	collagen type III alpha 1 chain
+ORPHANET:136	Cerebral autosomal dominant arteriopathy-subcortical infarcts-leukoencephalopathy	ENSEMBL:ENSG00000074181	notch receptor 3
+ORPHANET:275	Severe combined immunodeficiency due to DCLRE1C deficiency	ENSEMBL:ENSG00000152457	DNA cross-link repair 1C
+ORPHANET:184	Cherubism	ENSEMBL:ENSG00000087266	SH3 domain binding protein 2
+ORPHANET:71	Chylomicron retention disease	ENSEMBL:ENSG00000152700	secretion associated Ras related GTPase 1B
+ORPHANET:189	Hidrotic ectodermal dysplasia	ENSEMBL:ENSG00000121742	gap junction protein beta 6
+ORPHANET:1473	Uveal coloboma-cleft lip and palate-intellectual disability	ENSEMBL:ENSG00000137693	Yes1 associated transcriptional regulator
+ORPHANET:182050	MYH9-related disease	ENSEMBL:ENSG00000100345	myosin heavy chain 9
+ORPHANET:3103	Roberts syndrome	ENSEMBL:ENSG00000171320	establishment of sister chromatid cohesion N-acetyltransferase 2
+ORPHANET:709	Peters plus syndrome	ENSEMBL:ENSG00000187676	beta 3-glucosyltransferase
+ORPHANET:907	NON RARE IN EUROPE: Wolff-Parkinson-White syndrome	ENSEMBL:ENSG00000106617	protein kinase AMP-activated non-catalytic subunit gamma 2
+ORPHANET:902	Werner syndrome	ENSEMBL:ENSG00000165392	WRN RecQ like helicase
+ORPHANET:1587	Monosomy 13q14	ENSEMBL:ENSG00000139687	RB transcriptional corepressor 1
+ORPHANET:240	Léri-Weill dyschondrosteosis	ENSEMBL:ENSG00000185960	short stature homeobox
+ORPHANET:111	Barth syndrome	ENSEMBL:ENSG00000102125	tafazzin, phospholipid-lysophospholipid transacylase
+ORPHANET:1308	C syndrome	ENSEMBL:ENSG00000153283	CD96 molecule
+ORPHANET:150	Nasopharyngeal carcinoma	ENSEMBL:ENSG00000100906	NFKB inhibitor alpha
+ORPHANET:133	Chronic beryllium disease	ENSEMBL:ENSG00000223865	major histocompatibility complex, class II, DP beta 1
+ORPHANET:1552	Currarino syndrome	ENSEMBL:ENSG00000130675	motor neuron and pancreas homeobox 1
+ORPHANET:624	Familial multiple nevi flammei	ENSEMBL:ENSG00000156052	G protein subunit alpha q
+ORPHANET:3000	Familial male-limited precocious puberty	ENSEMBL:ENSG00000138039	luteinizing hormone/choriogonadotropin receptor
+ORPHANET:920	Ablepharon macrostomia syndrome	ENSEMBL:ENSG00000233608	twist family bHLH transcription factor 2
+ORPHANET:931	Acheiropodia	ENSEMBL:ENSG00000105983	limb development membrane protein 1
+ORPHANET:2297	Insulin-resistance syndrome type A	ENSEMBL:ENSG00000171105	insulin receptor
+ORPHANET:921	Abruzzo-Erickson syndrome	ENSEMBL:ENSG00000122145	T-box transcription factor 22
+ORPHANET:31	Oxoglutaric aciduria	ENSEMBL:ENSG00000105953	oxoglutarate dehydrogenase
+ORPHANET:37	Acrodermatitis enteropathica	ENSEMBL:ENSG00000147804	solute carrier family 39 member 4
+ORPHANET:955	Hajdu-Cheney syndrome	ENSEMBL:ENSG00000134250	notch receptor 2
+ORPHANET:1713	17p11.2 microduplication syndrome	ENSEMBL:ENSG00000108557	retinoic acid induced 1
+ORPHANET:1762	Proximal Xq28 duplication syndrome	ENSEMBL:ENSG00000169057	methyl-CpG binding protein 2
+ORPHANET:1878	TRIM32-related limb-girdle muscular dystrophy R8	ENSEMBL:ENSG00000119401	tripartite motif containing 32
+ORPHANET:2604	Familial visceral myopathy	ENSEMBL:ENSG00000163017	actin gamma 2, smooth muscle
+ORPHANET:156	Carnitine palmitoyl transferase 1A deficiency	ENSEMBL:ENSG00000110090	carnitine palmitoyltransferase 1A
+ORPHANET:1072	Ankyloblepharon filiforme adnatum-cleft palate syndrome	ENSEMBL:ENSG00000073282	tumor protein p63
+ORPHANET:1053	Vein of Galen aneurysmal malformation	ENSEMBL:ENSG00000196411	EPH receptor B4
+ORPHANET:1106	Microphthalmia with limb anomalies	ENSEMBL:ENSG00000198732	SPARC related modular calcium binding 1
+ORPHANET:978	ADULT syndrome	ENSEMBL:ENSG00000073282	tumor protein p63
+ORPHANET:983	Testicular regression syndrome	ENSEMBL:ENSG00000150990	DEAH-box helicase 37
+ORPHANET:40	Acromesomelic dysplasia, Maroteaux type	ENSEMBL:ENSG00000159899	natriuretic peptide receptor 2
+ORPHANET:972	Hereditary continuous muscle fiber activity	ENSEMBL:ENSG00000111262	potassium voltage-gated channel subfamily A member 1
+ORPHANET:959	Acro-renal-ocular syndrome	ENSEMBL:ENSG00000101115	spalt like transcription factor 4
+ORPHANET:968	Acromesomelic dysplasia, Hunter-Thompson type	ENSEMBL:ENSG00000125965	growth differentiation factor 5
+ORPHANET:1031	Enamel-renal syndrome	ENSEMBL:ENSG00000108950	FAM20A golgi associated secretory pathway pseudokinase
+ORPHANET:64	Alström syndrome	ENSEMBL:ENSG00000116127	ALMS1 centrosome and basal body associated protein
+ORPHANET:139396	X-linked cerebral adrenoleukodystrophy	ENSEMBL:ENSG00000101986	ATP binding cassette subfamily D member 1
+ORPHANET:139399	Adrenomyeloneuropathy	ENSEMBL:ENSG00000101986	ATP binding cassette subfamily D member 1
+ORPHANET:139406	Encephalopathy due to prosaposin deficiency	ENSEMBL:ENSG00000197746	prosaposin
+ORPHANET:701	Alopecia universalis	ENSEMBL:ENSG00000168453	HR lysine demethylase and nuclear receptor corepressor
+ORPHANET:1010	Autosomal dominant palmoplantar keratoderma and congenital alopecia	ENSEMBL:ENSG00000152661	gap junction protein alpha 1
+ORPHANET:1001	2q37 microdeletion syndrome	ENSEMBL:ENSG00000068024	histone deacetylase 4
+ORPHANET:59	Allan-Herndon-Dudley syndrome	ENSEMBL:ENSG00000147100	solute carrier family 16 member 2
+ORPHANET:127	Borjeson-Forssman-Lehmann syndrome	ENSEMBL:ENSG00000156531	PHD finger protein 6
+ORPHANET:1263	Boomerang dysplasia	ENSEMBL:ENSG00000136068	filamin B
+ORPHANET:1234	Bartsocas-Papas syndrome	ENSEMBL:ENSG00000183421	receptor interacting serine/threonine kinase 4
+ORPHANET:1231	Barber-Say syndrome	ENSEMBL:ENSG00000233608	twist family bHLH transcription factor 2
+ORPHANET:1229	Congenital intrauterine infection-like syndrome	ENSEMBL:ENSG00000197822	occludin
+ORPHANET:109	Bannayan-Riley-Ruvalcaba syndrome	ENSEMBL:ENSG00000171862	phosphatase and tensin homolog
+ORPHANET:115	Congenital contractural arachnodactyly	ENSEMBL:ENSG00000138829	fibrillin 2
+ORPHANET:137625	Glycogen storage disease due to muscle and heart glycogen synthase deficiency	ENSEMBL:ENSG00000104812	glycogen synthase 1
+ORPHANET:137608	Segmental outgrowth-lipomatosis-arteriovenous malformation-epidermal nevus syndrome	ENSEMBL:ENSG00000171862	phosphatase and tensin homolog
+ORPHANET:1299	Branchioskeletogenital syndrome	ENSEMBL:ENSG00000140937	cadherin 11
+ORPHANET:1300	Autosomal dominant popliteal pterygium syndrome	ENSEMBL:ENSG00000117595	interferon regulatory factor 6
+ORPHANET:137634	Overgrowth-macrocephaly-facial dysmorphism syndrome	ENSEMBL:ENSG00000181481	ring finger protein 135
+ORPHANET:1297	Branchio-oculo-facial syndrome	ENSEMBL:ENSG00000137203	transcription factor AP-2 alpha
+ORPHANET:137639	Hypomyelinating leukodystrophy-ataxia-hypodontia-hypomyelination syndrome	ENSEMBL:ENSG00000148606	RNA polymerase III subunit A
+ORPHANET:1276	Brachydactyly-arterial hypertension syndrome	ENSEMBL:ENSG00000172572	phosphodiesterase 3A
+ORPHANET:1270	Bowen-Conradi syndrome	ENSEMBL:ENSG00000126749	EMG1 N1-specific pseudouridine methyltransferase
+ORPHANET:137605	Legius syndrome	ENSEMBL:ENSG00000166068	sprouty related EVH1 domain containing 1
+ORPHANET:1168	Ataxia-oculomotor apraxia type 1	ENSEMBL:ENSG00000137074	aprataxin
+ORPHANET:137834	Frank-Ter Haar syndrome	ENSEMBL:ENSG00000174705	SH3 and PX domains 2B
+ORPHANET:137831	X-linked intellectual disability-cerebellar hypoplasia syndrome	ENSEMBL:ENSG00000079482	oligophrenin 1
+ORPHANET:1170	Autosomal recessive cerebelloparenchymal disorder type 3	ENSEMBL:ENSG00000165688	peptidase, mitochondrial processing subunit alpha
+ORPHANET:1175	X-linked progressive cerebellar ataxia	ENSEMBL:ENSG00000169562	gap junction protein beta 1
+ORPHANET:1180	Ataxia-hypogonadism-choroidal dystrophy syndrome	ENSEMBL:ENSG00000032444	patatin like phospholipase domain containing 6
+ORPHANET:137681	Hepatoencephalopathy due to combined oxidative phosphorylation defect type 1	ENSEMBL:ENSG00000168827	G elongation factor mitochondrial 1
+ORPHANET:137675	Histiocytoid cardiomyopathy	ENSEMBL:ENSG00000198727	mitochondrially encoded cytochrome b
+ORPHANET:137678	Spondyloepiphyseal dysplasia with metatarsal shortening	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:137754	Neurological conditions associated with aminoacylase 1 deficiency	ENSEMBL:ENSG00000243989	aminoacylase 1
+ORPHANET:1145	Infantile-onset X-linked spinal muscular atrophy	ENSEMBL:ENSG00000130985	ubiquitin like modifier activating enzyme 1
+ORPHANET:137776	Lethal congenital contracture syndrome type 2	ENSEMBL:ENSG00000065361	erb-b2 receptor tyrosine kinase 3
+ORPHANET:1149	Kuskokwim syndrome	ENSEMBL:ENSG00000141756	FKBP prolyl isomerase 10
+ORPHANET:1159	Progressive pseudorheumatoid arthropathy of childhood	ENSEMBL:ENSG00000112761	cellular communication network factor 6
+ORPHANET:1215	Autosomal dominant optic atrophy plus syndrome	ENSEMBL:ENSG00000198836	OPA1 mitochondrial dynamin like GTPase
+ORPHANET:1216	Autosomal dominant congenital benign spinal muscular atrophy	ENSEMBL:ENSG00000111199	transient receptor potential cation channel subfamily V member 4
+ORPHANET:1225	Baller-Gerold syndrome	ENSEMBL:ENSG00000160957	RecQ like helicase 4
+ORPHANET:1226	Bamforth-Lazarus syndrome	ENSEMBL:ENSG00000178919	forkhead box E1
+ORPHANET:1186	Infantile-onset spinocerebellar ataxia	ENSEMBL:ENSG00000107815	twinkle mtDNA helicase
+ORPHANET:137898	Leukoencephalopathy with brain stem and spinal cord involvement-high lactate syndrome	ENSEMBL:ENSG00000117593	aspartyl-tRNA synthetase 2, mitochondrial
+ORPHANET:137902	Isolated optic nerve hypoplasia/aplasia	ENSEMBL:ENSG00000007372	paired box 6
+ORPHANET:1187	Lethal ataxia with deafness and optic atrophy	ENSEMBL:ENSG00000147224	phosphoribosyl pyrophosphate synthetase 1
+ORPHANET:1190	Atelosteogenesis type I	ENSEMBL:ENSG00000136068	filamin B
+ORPHANET:137908	Hypotonia with lactic acidemia and hyperammonemia	ENSEMBL:ENSG00000175110	mitochondrial ribosomal protein S22
+ORPHANET:141258	Tessier number 4 facial cleft	ENSEMBL:ENSG00000100014	sperm antigen with calponin homology and coiled-coil domains 1 like
+ORPHANET:1458	CODAS syndrome	ENSEMBL:ENSG00000196365	lon peptidase 1, mitochondrial
+ORPHANET:190	Coats disease	ENSEMBL:ENSG00000124479	norrin cystine knot growth factor NDP
+ORPHANET:1426	Greenberg dysplasia	ENSEMBL:ENSG00000143815	lamin B receptor
+ORPHANET:1427	Otospondylomegaepiphyseal dysplasia	ENSEMBL:ENSG00000204248	collagen type XI alpha 2 chain
+ORPHANET:1435	Xq21 microdeletion syndrome	ENSEMBL:ENSG00000196767	POU class 3 homeobox 4
+ORPHANET:1490	Corneal dystrophy-perceptive deafness syndrome	ENSEMBL:ENSG00000088836	solute carrier family 4 member 11
+ORPHANET:1486	Lethal congenital contracture syndrome type 1	ENSEMBL:ENSG00000119392	GLE1 RNA export mediator
+ORPHANET:1412	Tarsal-carpal coalition syndrome	ENSEMBL:ENSG00000183691	noggin
+ORPHANET:1394	Cerebrofaciothoracic dysplasia	ENSEMBL:ENSG00000143183	transmembrane and coiled-coil domains 1
+ORPHANET:1401	CHAND syndrome	ENSEMBL:ENSG00000183421	receptor interacting serine/threonine kinase 4
+ORPHANET:141074	External auditory canal aplasia/hypoplasia	ENSEMBL:ENSG00000179981	teashirt zinc finger homeobox 1
+ORPHANET:174	Metaphyseal chondrodysplasia, Schmid type	ENSEMBL:ENSG00000123500	collagen type X alpha 1 chain
+ORPHANET:156728	Spondyloepimetaphyseal dysplasia, matrilin-3 type	ENSEMBL:ENSG00000132031	matrilin 3
+ORPHANET:163	Hereditary hyperferritinemia-cataract syndrome	ENSEMBL:ENSG00000087086	ferritin light chain
+ORPHANET:1393	Cerebrocostomandibular syndrome	ENSEMBL:ENSG00000125835	small nuclear ribonucleoprotein polypeptides B and B1
+ORPHANET:157798	Serrated polyposis syndrome	ENSEMBL:ENSG00000108375	ring finger protein 43
+ORPHANET:1388	Catel-Manzke syndrome	ENSEMBL:ENSG00000088451	TDP-glucose 4,6-dehydratase
+ORPHANET:157801	Mesoaxial synostotic syndactyly with phalangeal reduction	ENSEMBL:ENSG00000205899	basic helix-loop-helix family member a9
+ORPHANET:1328	Camurati-Engelmann disease	ENSEMBL:ENSG00000105329	transforming growth factor beta 1
+ORPHANET:1338	Heart defect-tongue hamartoma-polysyndactyly syndrome	ENSEMBL:ENSG00000143951	WD repeat containing planar cell polarity effector
+ORPHANET:1777	Temtamy syndrome	ENSEMBL:ENSG00000111678	chromosome 12 open reading frame 57
+ORPHANET:1772	45,X/46,XY mixed gonadal dysgenesis	ENSEMBL:ENSG00000184895	sex determining region Y
+ORPHANET:1788	Acrofacial dysostosis, Rodríguez type	ENSEMBL:ENSG00000143368	splicing factor 3b subunit 4
+ORPHANET:859	Transcobalamin deficiency	ENSEMBL:ENSG00000185339	transcobalamin 2
+ORPHANET:139447	Progressive cavitating leukoencephalopathy	ENSEMBL:ENSG00000178127	NADH:ubiquinone oxidoreductase core subunit V2
+ORPHANET:1573	Hypotrichosis with juvenile macular degeneration	ENSEMBL:ENSG00000062038	cadherin 3
+ORPHANET:726	Alpers-Huttenlocher syndrome	ENSEMBL:ENSG00000140521	DNA polymerase gamma, catalytic subunit
+ORPHANET:139455	Autosomal recessive bestrophinopathy	ENSEMBL:ENSG00000167995	bestrophin 1
+ORPHANET:139466	SERKAL syndrome	ENSEMBL:ENSG00000162552	Wnt family member 4
+ORPHANET:1596	Distal monosomy 15q	ENSEMBL:ENSG00000140563	multiple C2 and transmembrane domain containing 2
+ORPHANET:139471	Microphthalmia with brain and digit anomalies	ENSEMBL:ENSG00000125378	bone morphogenetic protein 4
+ORPHANET:139474	17q11.2 microduplication syndrome	ENSEMBL:ENSG00000196712	neurofibromin 1
+ORPHANET:1617	2q24 microdeletion syndrome	ENSEMBL:ENSG00000136535	T-box brain transcription factor 1
+ORPHANET:139480	Autosomal recessive spastic paraplegia type 39	ENSEMBL:ENSG00000032444	patatin like phospholipase domain containing 6
+ORPHANET:139485	Autosomal recessive ataxia due to ubiquinone deficiency	ENSEMBL:ENSG00000163050	coenzyme Q8A
+ORPHANET:139498	NON RARE IN EUROPE: Hemochromatosis type 1	ENSEMBL:ENSG00000010704	homeostatic iron regulator
+ORPHANET:139515	Charcot-Marie-Tooth disease type 4J	ENSEMBL:ENSG00000112367	FIG4 phosphoinositide 5-phosphatase
+ORPHANET:139512	Neuropathy with hearing impairment	ENSEMBL:ENSG00000188910	gap junction protein beta 3
+ORPHANET:1658	Absence of fingerprints-congenital milia syndrome	ENSEMBL:ENSG00000163104	SWI/SNF-related, matrix-associated actin-dependent regulator of chromatin, subfamily a, containing DEAD/H box 1
+ORPHANET:139557	X-linked distal spinal muscular atrophy type 3	ENSEMBL:ENSG00000165240	ATPase copper transporting alpha
+ORPHANET:139552	Distal hereditary motor neuropathy, Jerash type	ENSEMBL:ENSG00000147955	sigma non-opioid intracellular receptor 1
+ORPHANET:139583	X-linked hereditary sensory and autonomic neuropathy with deafness	ENSEMBL:ENSG00000156709	apoptosis inducing factor mitochondria associated 1
+ORPHANET:1667	Wolcott-Rallison syndrome	ENSEMBL:ENSG00000172071	eukaryotic translation initiation factor 2 alpha kinase 3
+ORPHANET:139578	Mutilating hereditary sensory neuropathy with spastic paraplegia	ENSEMBL:ENSG00000150753	chaperonin containing TCP1 subunit 5
+ORPHANET:140917	Stapes ankylosis with broad thumbs and toes	ENSEMBL:ENSG00000183691	noggin
+ORPHANET:140922	Titin-related limb-girdle muscular dystrophy R10	ENSEMBL:ENSG00000155657	titin
+ORPHANET:140905	Hyperlipidemia due to hepatic triacylglycerol lipase deficiency	ENSEMBL:ENSG00000166035	lipase C, hepatic type
+ORPHANET:1540	Jackson-Weiss syndrome	ENSEMBL:ENSG00000066468	fibroblast growth factor receptor 2
+ORPHANET:140908	Brachydactyly type B2	ENSEMBL:ENSG00000183691	noggin
+ORPHANET:140952	Syndactyly-telecanthus-anogenital and renal malformations syndrome	ENSEMBL:ENSG00000262919	cyclin Q
+ORPHANET:140944	CLOVES syndrome	ENSEMBL:ENSG00000121879	phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunit alpha
+ORPHANET:1555	Cutis gyrata-acanthosis nigricans-craniosynostosis syndrome	ENSEMBL:ENSG00000066468	fibroblast growth factor receptor 2
+ORPHANET:140941	Short stature due to primary acid-labile subunit deficiency	ENSEMBL:ENSG00000099769	insulin like growth factor binding protein acid labile subunit
+ORPHANET:1553	Curry-Jones syndrome	ENSEMBL:ENSG00000128602	smoothened, frizzled class receptor
+ORPHANET:140976	RHYNS syndrome	ENSEMBL:ENSG00000164953	transmembrane protein 67
+ORPHANET:140966	Palmoplantar keratoderma, Nagashima type	ENSEMBL:ENSG00000166396	serpin family B member 7
+ORPHANET:140963	Bilateral microtia-deafness-cleft palate syndrome	ENSEMBL:ENSG00000105996	homeobox A2
+ORPHANET:382	Guanidinoacetate methyltransferase deficiency	ENSEMBL:ENSG00000130005	guanidinoacetate N-methyltransferase
+ORPHANET:742	Prolidase deficiency	ENSEMBL:ENSG00000124299	peptidase D
+ORPHANET:1568	X-linked intellectual disability-Dandy-Walker malformation-basal ganglia disease-seizures syndrome	ENSEMBL:ENSG00000182287	adaptor related protein complex 1 subunit sigma 2
+ORPHANET:1497	X-linked complicated corpus callosum dysgenesis	ENSEMBL:ENSG00000198910	L1 cell adhesion molecule
+ORPHANET:140436	Primary intraosseous venous malformation	ENSEMBL:ENSG00000062598	engulfment and cell motility 2
+ORPHANET:1493	Vici syndrome	ENSEMBL:ENSG00000152223	ectopic P-granules 5 autophagy tethering factor
+ORPHANET:1509	Coxopodopatellar syndrome	ENSEMBL:ENSG00000121075	T-box transcription factor 4
+ORPHANET:1519	SPECC1L-related hypertelorism syndrome	ENSEMBL:ENSG00000100014	sperm antigen with calponin homology and coiled-coil domains 1 like
+ORPHANET:1520	Craniofrontonasal dysplasia	ENSEMBL:ENSG00000090776	ephrin B1
+ORPHANET:1513	Craniodiaphyseal dysplasia	ENSEMBL:ENSG00000167941	sclerostin
+ORPHANET:140481	Autosomal dominant slowed nerve conduction velocity	ENSEMBL:ENSG00000104728	Rho guanine nucleotide exchange factor 10
+ORPHANET:1529	Craniofacial-deafness-hand syndrome	ENSEMBL:ENSG00000135903	paired box 3
+ORPHANET:1525	Cranio-osteoarthropathy	ENSEMBL:ENSG00000164120	15-hydroxyprostaglandin dehydrogenase
+ORPHANET:1824	Lowry-Wood syndrome	ENSEMBL:ENSG00000264229	RNA, U4atac small nuclear (U12-dependent splicing)
+ORPHANET:1955	Spinocerebellar ataxia type 34	ENSEMBL:ENSG00000118402	ELOVL fatty acid elongase 4
+ORPHANET:2209	Maternal phenylketonuria	ENSEMBL:ENSG00000171759	phenylalanine hydroxylase
+ORPHANET:1896	EEC syndrome	ENSEMBL:ENSG00000073282	tumor protein p63
+ORPHANET:1897	EEM syndrome	ENSEMBL:ENSG00000062038	cadherin 3
+ORPHANET:1807	Focal facial dermal dysplasia type III	ENSEMBL:ENSG00000233608	twist family bHLH transcription factor 2
+ORPHANET:1873	Jalili syndrome	ENSEMBL:ENSG00000158158	cyclin and CBS domain divalent metal cation transport mediator 4
+ORPHANET:1879	Melorheostosis with osteopoikilosis	ENSEMBL:ENSG00000174106	LEM domain containing 3
+ORPHANET:1860	Thanatophoric dysplasia type 1	ENSEMBL:ENSG00000068078	fibroblast growth factor receptor 3
+ORPHANET:1865	Dyssegmental dysplasia, Silverman-Handmaker type	ENSEMBL:ENSG00000142798	heparan sulfate proteoglycan 2
+ORPHANET:1830	Schimke immuno-osseous dysplasia	ENSEMBL:ENSG00000138375	SWI/SNF related, matrix associated, actin dependent regulator of chromatin, subfamily a like 1
+ORPHANET:1802	Ghosal hematodiaphyseal dysplasia	ENSEMBL:ENSG00000059377	thromboxane A synthase 1
+ORPHANET:2143	Donnai-Barrow syndrome	ENSEMBL:ENSG00000081479	LDL receptor related protein 2
+ORPHANET:2148	Lissencephaly type 1 due to doublecortin gene mutation	ENSEMBL:ENSG00000077279	doublecortin
+ORPHANET:2114	Hip dysplasia, Beukes type	ENSEMBL:ENSG00000109775	UFM1 specific peptidase 2
+ORPHANET:2117	Hartsfield syndrome	ENSEMBL:ENSG00000077782	fibroblast growth factor receptor 1
+ORPHANET:376	Gordon syndrome	ENSEMBL:ENSG00000154864	piezo type mechanosensitive ion channel component 2
+ORPHANET:2092	Focal dermal hypoplasia	ENSEMBL:ENSG00000102312	porcupine O-acyltransferase
+ORPHANET:380	Greig cephalopolysyndactyly syndrome	ENSEMBL:ENSG00000106571	GLI family zinc finger 3
+ORPHANET:2095	Gorlin-Chaudhry-Moss syndrome	ENSEMBL:ENSG00000085491	solute carrier family 25 member 24
+ORPHANET:158029	Sea-blue histiocytosis	ENSEMBL:ENSG00000130203	apolipoprotein E
+ORPHANET:157846	Neuroferritinopathy	ENSEMBL:ENSG00000087086	ferritin light chain
+ORPHANET:2067	GAPO syndrome	ENSEMBL:ENSG00000169604	ANTXR cell adhesion molecule 1
+ORPHANET:157941	Huntington disease-like 1	ENSEMBL:ENSG00000171867	prion protein
+ORPHANET:2072	Gaucher disease-ophthalmoplegia-cardiovascular calcification syndrome	ENSEMBL:ENSG00000177628	glucosylceramidase beta 1
+ORPHANET:157954	ANE syndrome	ENSEMBL:ENSG00000106344	RNA binding motif protein 28
+ORPHANET:157962	Oculoauricular syndrome, Schorderet type	ENSEMBL:ENSG00000215612	H6 family homeobox 1
+ORPHANET:157973	Congenital muscular dystrophy due to LMNA mutation	ENSEMBL:ENSG00000160789	lamin A/C
+ORPHANET:2084	Glaucoma-ectopia lentis-microspherophakia-stiff joints-short stature syndrome	ENSEMBL:ENSG00000166147	fibrillin 1
+ORPHANET:157965	SLC39A13-related spondylodysplastic Ehlers-Danlos syndrome	ENSEMBL:ENSG00000165915	solute carrier family 39 member 13
+ORPHANET:2059	Fryns syndrome	ENSEMBL:ENSG00000197563	phosphatidylinositol glycan anchor biosynthesis class N
+ORPHANET:2026	Gingival fibromatosis-hypertrichosis syndrome	ENSEMBL:ENSG00000154265	ATP binding cassette subfamily A member 5
+ORPHANET:2028	Juvenile hyaline fibromatosis	ENSEMBL:ENSG00000163297	ANTXR cell adhesion molecule 2
+ORPHANET:2044	Floating-Harbor syndrome	ENSEMBL:ENSG00000080603	Snf2 related CREBBP activator protein
+ORPHANET:2036	Scalp-ear-nipple syndrome	ENSEMBL:ENSG00000134504	potassium channel tetramerization domain containing 1
+ORPHANET:158769	Plaque-form urticaria pigmentosa	ENSEMBL:ENSG00000157404	KIT proto-oncogene, receptor tyrosine kinase
+ORPHANET:158766	Typical urticaria pigmentosa	ENSEMBL:ENSG00000157404	KIT proto-oncogene, receptor tyrosine kinase
+ORPHANET:158681	Epidermolysis bullosa simplex with circinate migratory erythema	ENSEMBL:ENSG00000186081	keratin 5
+ORPHANET:158676	Localized dystrophic epidermolysis bullosa, nails only	ENSEMBL:ENSG00000114270	collagen type VII alpha 1 chain
+ORPHANET:158673	Localized dystrophic epidermolysis bullosa, acral form	ENSEMBL:ENSG00000114270	collagen type VII alpha 1 chain
+ORPHANET:158668	Ectodermal dysplasia-skin fragility syndrome	ENSEMBL:ENSG00000081277	plakophilin 1
+ORPHANET:158778	Isolated bone marrow mastocytosis	ENSEMBL:ENSG00000157404	KIT proto-oncogene, receptor tyrosine kinase
+ORPHANET:158775	Smoldering systemic mastocytosis	ENSEMBL:ENSG00000157404	KIT proto-oncogene, receptor tyrosine kinase
+ORPHANET:158772	Nodular urticaria pigmentosa	ENSEMBL:ENSG00000157404	KIT proto-oncogene, receptor tyrosine kinase
+ORPHANET:1986	Gollop-Wolfgang complex	ENSEMBL:ENSG00000205899	basic helix-loop-helix family member a9
+ORPHANET:2348	Familial partial lipodystrophy, Dunnigan type	ENSEMBL:ENSG00000160789	lamin A/C
+ORPHANET:247768	Müllerian aplasia and hyperandrogenism	ENSEMBL:ENSG00000162552	Wnt family member 4
+ORPHANET:2353	Schilbach-Rott syndrome	ENSEMBL:ENSG00000185920	patched 1
+ORPHANET:247790	FTH1-related iron overload	ENSEMBL:ENSG00000167996	ferritin heavy chain 1
+ORPHANET:247798	MUTYH-related attenuated familial adenomatous polyposis	ENSEMBL:ENSG00000132781	mutY DNA glycosylase
+ORPHANET:247794	Juvenile cataract-microcornea-renal glucosuria syndrome	ENSEMBL:ENSG00000152779	solute carrier family 16 member 12
+ORPHANET:247815	Autosomal recessive ataxia due to PEX10 deficiency	ENSEMBL:ENSG00000157911	peroxisomal biogenesis factor 10
+ORPHANET:247806	APC-related attenuated familial adenomatous polyposis	ENSEMBL:ENSG00000134982	APC regulator of WNT signaling pathway
+ORPHANET:247691	Retinal vasculopathy with cerebral leukoencephalopathy and systemic manifestations	ENSEMBL:ENSG00000213689	three prime repair exonuclease 1
+ORPHANET:247685	Odontohypophosphatasia	ENSEMBL:ENSG00000162551	alkaline phosphatase, biomineralization associated
+ORPHANET:2342	Haim-Munk syndrome	ENSEMBL:ENSG00000109861	cathepsin C
+ORPHANET:247709	Multiple endocrine neoplasia type 2B	ENSEMBL:ENSG00000165731	ret proto-oncogene
+ORPHANET:247698	Multiple endocrine neoplasia type 2A	ENSEMBL:ENSG00000165731	ret proto-oncogene
+ORPHANET:485	Kniest dysplasia	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:247585	Citrullinemia type II	ENSEMBL:ENSG00000004864	solute carrier family 25 member 13
+ORPHANET:247598	Neonatal intrahepatic cholestasis due to citrin deficiency	ENSEMBL:ENSG00000004864	solute carrier family 25 member 13
+ORPHANET:2332	KBG syndrome	ENSEMBL:ENSG00000167522	ankyrin repeat domain containing 11
+ORPHANET:247623	Perinatal lethal hypophosphatasia	ENSEMBL:ENSG00000162551	alkaline phosphatase, biomineralization associated
+ORPHANET:2335	NON RARE IN EUROPE: Isolated keratoconus	ENSEMBL:ENSG00000100987	visual system homeobox 1
+ORPHANET:247638	Prenatal benign hypophosphatasia	ENSEMBL:ENSG00000162551	alkaline phosphatase, biomineralization associated
+ORPHANET:2337	Non-epidermolytic palmoplantar keratoderma	ENSEMBL:ENSG00000161798	aquaporin 5
+ORPHANET:247651	Infantile hypophosphatasia	ENSEMBL:ENSG00000162551	alkaline phosphatase, biomineralization associated
+ORPHANET:247667	Childhood-onset hypophosphatasia	ENSEMBL:ENSG00000162551	alkaline phosphatase, biomineralization associated
+ORPHANET:247676	Adult hypophosphatasia	ENSEMBL:ENSG00000162551	alkaline phosphatase, biomineralization associated
+ORPHANET:494	Keratoderma hereditarium mutilans	ENSEMBL:ENSG00000165474	gap junction protein beta 2
+ORPHANET:247378	Autosomal recessive secondary polycythemia not associated with VHL gene	ENSEMBL:ENSG00000172331	bisphosphoglycerate mutase
+ORPHANET:2323	Sanjad-Sakati syndrome	ENSEMBL:ENSG00000284770	tubulin folding cofactor E
+ORPHANET:247522	Primary ciliary dyskinesia-retinitis pigmentosa syndrome	ENSEMBL:ENSG00000156313	retinitis pigmentosa GTPase regulator
+ORPHANET:247546	Acute neonatal citrullinemia type I	ENSEMBL:ENSG00000130707	argininosuccinate synthase 1
+ORPHANET:247573	Adult-onset citrullinemia type I	ENSEMBL:ENSG00000130707	argininosuccinate synthase 1
+ORPHANET:2407	Laryngo-onycho-cutaneous syndrome	ENSEMBL:ENSG00000053747	laminin subunit alpha 3
+ORPHANET:248340	Isolated delta-storage pool disease	ENSEMBL:ENSG00000151702	Fli-1 proto-oncogene, ETS transcription factor
+ORPHANET:2388	Choreoacanthocytosis	ENSEMBL:ENSG00000197969	vacuolar protein sorting 13 homolog A
+ORPHANET:248111	Juvenile Huntington disease	ENSEMBL:ENSG00000197386	huntingtin
+ORPHANET:2387	Leukonychia totalis	ENSEMBL:ENSG00000187091	phospholipase C delta 1
+ORPHANET:2379	Early-onset parkinsonism-intellectual disability syndrome	ENSEMBL:ENSG00000155961	RAB39B, member RAS oncogene family
+ORPHANET:247834	Occult macular dystrophy	ENSEMBL:ENSG00000183638	RP1 like 1
+ORPHANET:247820	Ectodermal dysplasia-syndactyly syndrome	ENSEMBL:ENSG00000143217	nectin cell adhesion molecule 4
+ORPHANET:2378	Laurin-Sandrow syndrome	ENSEMBL:ENSG00000105983	limb development membrane protein 1
+ORPHANET:247868	NLRP12-associated hereditary periodic fever syndrome	ENSEMBL:ENSG00000142405	NLR family pyrin domain containing 12
+ORPHANET:2451	Mucocutaneous venous malformations	ENSEMBL:ENSG00000120156	TEK receptor tyrosine kinase
+ORPHANET:244283	Biliary atresia with splenic malformation syndrome	ENSEMBL:ENSG00000136698	cripto, FRL-1, cryptic family 1
+ORPHANET:244310	RFT1-CDG	ENSEMBL:ENSG00000163933	RFT1 homolog
+ORPHANET:2438	Hand-foot-genital syndrome	ENSEMBL:ENSG00000106031	homeobox A13
+ORPHANET:243343	Dimethylglycine dehydrogenase deficiency	ENSEMBL:ENSG00000132837	dimethylglycine dehydrogenase
+ORPHANET:243367	Acute fatty liver of pregnancy	ENSEMBL:ENSG00000084754	hydroxyacyl-CoA dehydrogenase trifunctional multienzyme complex subunit alpha
+ORPHANET:2484	Melnick-Needles syndrome	ENSEMBL:ENSG00000196924	filamin A
+ORPHANET:2473	McKusick-Kaufman syndrome	ENSEMBL:ENSG00000125863	MKKS centrosomal shuttling protein
+ORPHANET:561	Marshall-Smith syndrome	ENSEMBL:ENSG00000008441	nuclear factor I X
+ORPHANET:2461	Marden-Walker syndrome	ENSEMBL:ENSG00000154864	piezo type mechanosensitive ion channel component 2
+ORPHANET:2176	Infantile systemic hyalinosis	ENSEMBL:ENSG00000163297	ANTXR cell adhesion molecule 2
+ORPHANET:251656	Oligoastrocytoma	ENSEMBL:ENSG00000182054	isocitrate dehydrogenase (NADP(+)) 2
+ORPHANET:251663	Anaplastic oligoastrocytoma	ENSEMBL:ENSG00000182054	isocitrate dehydrogenase (NADP(+)) 2
+ORPHANET:2196	Primary hypomagnesemia with hypercalciuria and nephrocalcinosis with severe ocular involvement	ENSEMBL:ENSG00000164007	claudin 19
+ORPHANET:251589	Anaplastic astrocytoma	ENSEMBL:ENSG00000182054	isocitrate dehydrogenase (NADP(+)) 2
+ORPHANET:251598	Protoplasmic astrocytoma	ENSEMBL:ENSG00000182054	isocitrate dehydrogenase (NADP(+)) 2
+ORPHANET:251604	Gemistocytic astrocytoma	ENSEMBL:ENSG00000182054	isocitrate dehydrogenase (NADP(+)) 2
+ORPHANET:251601	Fibrillary astrocytoma	ENSEMBL:ENSG00000182054	isocitrate dehydrogenase (NADP(+)) 2
+ORPHANET:2169	Methylcobalamin deficiency type cblE	ENSEMBL:ENSG00000124275	5-methyltetrahydrofolate-homocysteine methyltransferase reductase
+ORPHANET:2228	Hypodontia-dysplasia of nails syndrome	ENSEMBL:ENSG00000163132	msh homeobox 1
+ORPHANET:2224	Hypertryptophanemia	ENSEMBL:ENSG00000151790	tryptophan 2,3-dioxygenase
+ORPHANET:2229	Dilated cardiomyopathy-hypergonadotropic hypogonadism syndrome	ENSEMBL:ENSG00000160789	lamin A/C
+ORPHANET:2237	Hypoparathyroidism-sensorineural deafness-renal disease syndrome	ENSEMBL:ENSG00000107485	GATA binding protein 3
+ORPHANET:251863	Desmoplastic/nodular medulloblastoma	ENSEMBL:ENSG00000107882	SUFU negative regulator of hedgehog signaling
+ORPHANET:2198	Palmoplantar keratoderma-esophageal carcinoma syndrome	ENSEMBL:ENSG00000129667	rhomboid 5 homolog 2
+ORPHANET:251858	Medulloblastoma with extensive nodularity	ENSEMBL:ENSG00000107882	SUFU negative regulator of hedgehog signaling
+ORPHANET:251899	Choroid plexus carcinoma	ENSEMBL:ENSG00000141510	tumor protein p53
+ORPHANET:251019	2q32q33 microdeletion syndrome	ENSEMBL:ENSG00000119042	SATB homeobox 2
+ORPHANET:251028	SATB2-associated syndrome due to a chromosomal rearrangement	ENSEMBL:ENSG00000119042	SATB homeobox 2
+ORPHANET:672	Pallister-Hall syndrome	ENSEMBL:ENSG00000106571	GLI family zinc finger 3
+ORPHANET:455	Superficial epidermolytic ichthyosis	ENSEMBL:ENSG00000172867	keratin 2
+ORPHANET:251061	7q31 microdeletion syndrome	ENSEMBL:ENSG00000128573	forkhead box P2
+ORPHANET:251066	8p11.2 deletion syndrome	ENSEMBL:ENSG00000029534	ankyrin 1
+ORPHANET:251071	8p23.1 microdeletion syndrome	ENSEMBL:ENSG00000136574	GATA binding protein 4
+ORPHANET:2273	Ichthyosis follicularis-alopecia-photophobia syndrome	ENSEMBL:ENSG00000012174	membrane bound transcription factor peptidase, site 2
+ORPHANET:139	CHILD syndrome	ENSEMBL:ENSG00000147383	NAD(P) dependent steroid dehydrogenase-like
+ORPHANET:457	Harlequin ichthyosis	ENSEMBL:ENSG00000144452	ATP binding cassette subfamily A member 12
+ORPHANET:251056	6q25 microdeletion syndrome	ENSEMBL:ENSG00000049618	AT-rich interaction domain 1B
+ORPHANET:2239	Familial isolated hypoparathyroidism due to agenesis of parathyroid gland	ENSEMBL:ENSG00000124827	glial cells missing transcription factor 2
+ORPHANET:250977	AICA-ribosiduria	ENSEMBL:ENSG00000138363	5-aminoimidazole-4-carboxamide ribonucleotide formyltransferase/IMP cyclohydrolase
+ORPHANET:2250	Hyposmia-nasal and ocular hypoplasia-hypogonadotropic hypogonadism syndrome	ENSEMBL:ENSG00000101596	structural maintenance of chromosomes flexible hinge domain containing 1
+ORPHANET:250972	Polymicrogyria with optic nerve hypoplasia	ENSEMBL:ENSG00000183785	tubulin alpha 8
+ORPHANET:2255	Pancreatic hypoplasia-diabetes-congenital heart disease syndrome	ENSEMBL:ENSG00000141448	GATA binding protein 6
+ORPHANET:251383	CK syndrome	ENSEMBL:ENSG00000147383	NAD(P) dependent steroid dehydrogenase-like
+ORPHANET:251370	Sickle cell-hemoglobin D disease syndrome	ENSEMBL:ENSG00000244734	hemoglobin subunit beta
+ORPHANET:251375	Sickle cell-hemoglobin E disease syndrome	ENSEMBL:ENSG00000244734	hemoglobin subunit beta
+ORPHANET:251359	Sickle cell-beta-thalassemia disease syndrome	ENSEMBL:ENSG00000244734	hemoglobin subunit beta
+ORPHANET:251365	Sickle cell-hemoglobin C disease syndrome	ENSEMBL:ENSG00000244734	hemoglobin subunit beta
+ORPHANET:2319	Juberg-Hayward syndrome	ENSEMBL:ENSG00000171320	establishment of sister chromatid cohesion N-acetyltransferase 2
+ORPHANET:251523	Hyperzincemia and hypercalprotectinemia	ENSEMBL:ENSG00000140368	proline-serine-threonine phosphatase interacting protein 1
+ORPHANET:2315	Johanson-Blizzard syndrome	ENSEMBL:ENSG00000159459	ubiquitin protein ligase E3 component n-recognin 1
+ORPHANET:2307	IVIC syndrome	ENSEMBL:ENSG00000101115	spalt like transcription factor 4
+ORPHANET:251295	Pigmented paravenous retinochoroidal atrophy	ENSEMBL:ENSG00000134376	crumbs cell polarity complex component 1
+ORPHANET:251290	Parietal foramina with clavicular hypoplasia	ENSEMBL:ENSG00000120149	msh homeobox 2
+ORPHANET:251287	Benign concentric annular macular dystrophy	ENSEMBL:ENSG00000112706	interphotoreceptor matrix proteoglycan 1
+ORPHANET:251282	Autosomal dominant spastic ataxia type 1	ENSEMBL:ENSG00000139190	vesicle associated membrane protein 1
+ORPHANET:251279	Microphthalmia-retinitis pigmentosa-foveoschisis-optic disc drusen syndrome	ENSEMBL:ENSG00000235718	membrane frizzled-related protein
+ORPHANET:251274	Familial hyperaldosteronism type III	ENSEMBL:ENSG00000120457	potassium inwardly rectifying channel subfamily J member 5
+ORPHANET:251262	Familial osteochondritis dissecans	ENSEMBL:ENSG00000157766	aggrecan
+ORPHANET:251347	Ataxia-telangiectasia-like disorder	ENSEMBL:ENSG00000020922	MRE11 homolog, double strand break repair nuclease
+ORPHANET:2289	Neuronal intranuclear inclusion disease	ENSEMBL:ENSG00000286219	notch 2 N-terminal like C
+ORPHANET:254857	Lethal infantile mitochondrial myopathy	ENSEMBL:ENSG00000210195	mitochondrially encoded tRNA-Thr (ACN)
+ORPHANET:2662	Keipert syndrome	ENSEMBL:ENSG00000076716	glypican 4
+ORPHANET:1475	Renal coloboma syndrome	ENSEMBL:ENSG00000075891	paired box 2
+ORPHANET:2670	Pierson syndrome	ENSEMBL:ENSG00000172037	laminin subunit beta 2
+ORPHANET:254930	Combined oxidative phosphorylation defect type 7	ENSEMBL:ENSG00000130921	mitochondrial translation release factor in rescue
+ORPHANET:254925	Combined oxidative phosphorylation defect type 4	ENSEMBL:ENSG00000178952	Tu translation elongation factor, mitochondrial
+ORPHANET:254920	Combined oxidative phosphorylation defect type 2	ENSEMBL:ENSG00000182180	mitochondrial ribosomal protein S16
+ORPHANET:255182	Pyruvate dehydrogenase E3-binding protein deficiency	ENSEMBL:ENSG00000110435	pyruvate dehydrogenase complex component X
+ORPHANET:255138	Pyruvate dehydrogenase E1-beta deficiency	ENSEMBL:ENSG00000168291	pyruvate dehydrogenase E1 subunit beta
+ORPHANET:255132	Adult-onset autosomal recessive sideroblastic anemia	ENSEMBL:ENSG00000182512	glutaredoxin 5
+ORPHANET:2698	Knuckle pads-leukonychia-sensorineural deafness-palmoplantar hyperkeratosis syndrome	ENSEMBL:ENSG00000165474	gap junction protein beta 2
+ORPHANET:254881	Spinocerebellar ataxia with epilepsy	ENSEMBL:ENSG00000140521	DNA polymerase gamma, catalytic subunit
+ORPHANET:254875	Mitochondrial DNA depletion syndrome, myopathic form	ENSEMBL:ENSG00000166548	thymidine kinase 2
+ORPHANET:254902	Renal tubulopathy-encephalopathy-liver failure syndrome	ENSEMBL:ENSG00000074582	BCS1 homolog, ubiquinol-cytochrome c reductase complex chaperone
+ORPHANET:254898	Deafness-encephaloneuropathy-obesity-valvulopathy syndrome	ENSEMBL:ENSG00000148459	decaprenyl diphosphate synthase subunit 1
+ORPHANET:2712	Oculofaciocardiodental syndrome	ENSEMBL:ENSG00000183337	BCL6 corepressor
+ORPHANET:2717	Oculotrichoanal syndrome	ENSEMBL:ENSG00000164946	FRAS1 related extracellular matrix 1
+ORPHANET:255229	Navajo neurohepatopathy	ENSEMBL:ENSG00000115204	mitochondrial inner membrane protein MPV17
+ORPHANET:2707	Oculocerebrofacial syndrome, Kaufman type	ENSEMBL:ENSG00000151148	ubiquitin protein ligase E3B
+ORPHANET:255235	Mitochondrial DNA depletion syndrome, encephalomyopathic form with renal tubulopathy	ENSEMBL:ENSG00000048392	ribonucleotide reductase regulatory TP53 inducible subunit M2B
+ORPHANET:2710	Oculodentodigital dysplasia	ENSEMBL:ENSG00000152661	gap junction protein alpha 1
+ORPHANET:2728	Blepharophimosis-intellectual disability syndrome, Ohdo type	ENSEMBL:ENSG00000080503	SWI/SNF related, matrix associated, actin dependent regulator of chromatin, subfamily a, member 2
+ORPHANET:2721	Odonto-onycho-dermal dysplasia	ENSEMBL:ENSG00000135925	Wnt family member 10A
+ORPHANET:2725	Eye defects-arachnodactyly-cardiopathy syndrome	ENSEMBL:ENSG00000176022	beta-1,3-galactosyltransferase 6
+ORPHANET:2753	Orofaciodigital syndrome type 4	ENSEMBL:ENSG00000119977	tectonic family member 3
+ORPHANET:2752	Orofaciodigital syndrome type 3	ENSEMBL:ENSG00000205084	transmembrane protein 231
+ORPHANET:2751	Orofaciodigital syndrome type 2	ENSEMBL:ENSG00000137601	NIMA related kinase 1
+ORPHANET:2750	Orofaciodigital syndrome type 1	ENSEMBL:ENSG00000046651	OFD1 centriole and centriolar satellite protein
+ORPHANET:254361	Plectin-related limb-girdle muscular dystrophy R17	ENSEMBL:ENSG00000178209	plectin
+ORPHANET:2774	Multicentric carpo-tarsal osteolysis with or without nephropathy	ENSEMBL:ENSG00000204103	MAF bZIP transcription factor B
+ORPHANET:254343	Autosomal recessive spastic ataxia-optic atrophy-dysarthria syndrome	ENSEMBL:ENSG00000107951	mitochondrial poly(A) polymerase
+ORPHANET:254334	Autosomal recessive intermediate Charcot-Marie-Tooth disease type B	ENSEMBL:ENSG00000065427	lysyl-tRNA synthetase 1
+ORPHANET:2762	Progressive osseous heteroplasia	ENSEMBL:ENSG00000087460	GNAS complex locus
+ORPHANET:2763	Osteocraniostenosis	ENSEMBL:ENSG00000166801	FAM111 trypsin like peptidase A
+ORPHANET:252206	Melanoma and neural system tumor syndrome	ENSEMBL:ENSG00000147889	cyclin dependent kinase inhibitor 2A
+ORPHANET:2789	Lateral meningocele syndrome	ENSEMBL:ENSG00000074181	notch receptor 3
+ORPHANET:2788	Osteoporosis-pseudoglioma syndrome	ENSEMBL:ENSG00000162337	LDL receptor related protein 5
+ORPHANET:2791	Otodental syndrome	ENSEMBL:ENSG00000186895	fibroblast growth factor 3
+ORPHANET:2790	Endosteal hyperostosis, Worth type	ENSEMBL:ENSG00000162337	LDL receptor related protein 5
+ORPHANET:1306	Buschke-Ollendorff syndrome	ENSEMBL:ENSG00000174106	LEM domain containing 3
+ORPHANET:2783	Autosomal dominant osteopetrosis type 1	ENSEMBL:ENSG00000162337	LDL receptor related protein 5
+ORPHANET:2780	Osteopathia striata-cranial sclerosis syndrome	ENSEMBL:ENSG00000184675	APC membrane recruitment protein 1
+ORPHANET:2807	Papilloma of choroid plexus	ENSEMBL:ENSG00000141510	tumor protein p53
+ORPHANET:678	Papillon-Lefèvre syndrome	ENSEMBL:ENSG00000109861	cathepsin C
+ORPHANET:254704	Genetic hyperferritinemia without iron overload	ENSEMBL:ENSG00000087086	ferritin light chain
+ORPHANET:2802	X-linked sideroblastic anemia and spinocerebellar ataxia	ENSEMBL:ENSG00000131269	ATP binding cassette subfamily B member 7
+ORPHANET:2498	Syndactyly type 8	ENSEMBL:ENSG00000196468	fibroblast growth factor 16
+ORPHANET:2499	Metachondromatosis	ENSEMBL:ENSG00000179295	protein tyrosine phosphatase non-receptor type 11
+ORPHANET:2500	Acrogeria	ENSEMBL:ENSG00000168542	collagen type III alpha 1 chain
+ORPHANET:2501	Metaphyseal chondrodysplasia, Spahr type	ENSEMBL:ENSG00000137745	matrix metallopeptidase 13
+ORPHANET:2504	Metaphyseal dysplasia-maxillary hypoplasia-brachydacty syndrome	ENSEMBL:ENSG00000124813	RUNX family transcription factor 2
+ORPHANET:2508	Corpus callosum agenesis-abnormal genitalia syndrome	ENSEMBL:ENSG00000004848	aristaless related homeobox
+ORPHANET:2526	Microcephaly-lymphedema-chorioretinopathy syndrome	ENSEMBL:ENSG00000138160	kinesin family member 11
+ORPHANET:575	Muckle-Wells syndrome	ENSEMBL:ENSG00000162711	NLR family pyrin domain containing 3
+ORPHANET:2570	Lethal intrauterine growth restriction-cortical malformation-congenital contractures syndrome	ENSEMBL:ENSG00000068394	G-patch domain and KOW motifs
+ORPHANET:2585	Ataxia-pancytopenia syndrome	ENSEMBL:ENSG00000177409	sterile alpha motif domain containing 9 like
+ORPHANET:261144	FOXG1 syndrome due to 14q12 microdeletion	ENSEMBL:ENSG00000176165	forkhead box G1
+ORPHANET:2576	Mulibrey nanism	ENSEMBL:ENSG00000108395	tripartite motif containing 37
+ORPHANET:261222	Distal 16p11.2 microdeletion syndrome	ENSEMBL:ENSG00000178188	SH2B adaptor protein 1
+ORPHANET:261229	14q11.2 microduplication syndrome	ENSEMBL:ENSG00000176165	forkhead box G1
+ORPHANET:2590	Spinal muscular atrophy-progressive myoclonic epilepsy syndrome	ENSEMBL:ENSG00000104763	N-acylsphingosine amidohydrolase 1
+ORPHANET:261190	15q14 microdeletion syndrome	ENSEMBL:ENSG00000134138	Meis homeobox 2
+ORPHANET:2588	Myhre syndrome	ENSEMBL:ENSG00000141646	SMAD family member 4
+ORPHANET:261197	Proximal 16p11.2 microdeletion syndrome	ENSEMBL:ENSG00000178188	SH2B adaptor protein 1
+ORPHANET:261295	20p12.3 microdeletion syndrome	ENSEMBL:ENSG00000125845	bone morphogenetic protein 2
+ORPHANET:261279	17q23.1q23.2 microdeletion syndrome	ENSEMBL:ENSG00000121075	T-box transcription factor 4
+ORPHANET:261250	16q24.3 microdeletion syndrome	ENSEMBL:ENSG00000167522	ankyrin repeat domain containing 11
+ORPHANET:2613	Nail-patella-like renal disease	ENSEMBL:ENSG00000136944	LIM homeobox transcription factor 1 beta
+ORPHANET:261257	Distal 17p13.3 microdeletion syndrome	ENSEMBL:ENSG00000108953	tyrosine 3-monooxygenase/tryptophan 5-monooxygenase activation protein epsilon
+ORPHANET:261323	21q22.11q22.12 microdeletion syndrome	ENSEMBL:ENSG00000163808	kinesin family member 15
+ORPHANET:261483	Xq27.3q28 duplication syndrome	ENSEMBL:ENSG00000102081	fragile X messenger ribonucleoprotein 1
+ORPHANET:2632	Langer mesomelic dysplasia	ENSEMBL:ENSG00000185960	short stature homeobox
+ORPHANET:2646	Parastremmatic dwarfism	ENSEMBL:ENSG00000111199	transient receptor potential cation channel subfamily V member 4
+ORPHANET:2645	Osteoglosphonic dysplasia	ENSEMBL:ENSG00000077782	fibroblast growth factor receptor 1
+ORPHANET:261584	Familial adenomatous polyposis due to 5q22.2 microdeletion	ENSEMBL:ENSG00000134982	APC regulator of WNT signaling pathway
+ORPHANET:261600	Alagille syndrome due to 20p12 microdeletion	ENSEMBL:ENSG00000101384	jagged canonical Notch ligand 1
+ORPHANET:261619	Alagille syndrome due to a JAG1 point mutation	ENSEMBL:ENSG00000101384	jagged canonical Notch ligand 1
+ORPHANET:261537	Mowat-Wilson syndrome due to monosomy 2q22	ENSEMBL:ENSG00000169554	zinc finger E-box binding homeobox 2
+ORPHANET:261552	Mowat-Wilson syndrome due to a ZEB2 point mutation	ENSEMBL:ENSG00000169554	zinc finger E-box binding homeobox 2
+ORPHANET:2636	Microcephalic osteodysplastic primordial dwarfism types I and III	ENSEMBL:ENSG00000264229	RNA, U4atac small nuclear (U12-dependent splicing)
+ORPHANET:2658	Lenz-Majewski hyperostotic dwarfism	ENSEMBL:ENSG00000156471	phosphatidylserine synthase 1
+ORPHANET:261629	Alagille syndrome due to a NOTCH2 point mutation	ENSEMBL:ENSG00000134250	notch receptor 2
+ORPHANET:261638	Okihiro syndrome due to 20q13 microdeletion	ENSEMBL:ENSG00000101115	spalt like transcription factor 4
+ORPHANET:261647	Okihiro syndrome due to a point mutation	ENSEMBL:ENSG00000101115	spalt like transcription factor 4
+ORPHANET:3057	Monoamine oxidase A deficiency	ENSEMBL:ENSG00000189221	monoamine oxidase A
+ORPHANET:3047	Blepharophimosis-intellectual disability syndrome, SBBYS type	ENSEMBL:ENSG00000156650	lysine acetyltransferase 6B
+ORPHANET:3042	Intellectual disability-cataracts-calcified pinnae-myopathy syndrome	ENSEMBL:ENSG00000181722	zinc finger and BTB domain containing 20
+ORPHANET:263553	Peeling skin syndrome type B	ENSEMBL:ENSG00000204539	corneodesmosin
+ORPHANET:3032	NPHP3-related Meckel-like syndrome	ENSEMBL:ENSG00000113971	nephrocystin 3
+ORPHANET:263516	Progressive myoclonic epilepsy type 3	ENSEMBL:ENSG00000243335	potassium channel tetramerization domain containing 7
+ORPHANET:263501	COG4-CDG	ENSEMBL:ENSG00000103051	component of oligomeric golgi complex 4
+ORPHANET:263508	COG1-CDG	ENSEMBL:ENSG00000166685	component of oligomeric golgi complex 1
+ORPHANET:263482	Spondyloepiphyseal dysplasia, Maroteaux type	ENSEMBL:ENSG00000111199	transient receptor potential cation channel subfamily V member 4
+ORPHANET:3021	RAPADILINO syndrome	ENSEMBL:ENSG00000160957	RecQ like helicase 4
+ORPHANET:263494	DPM3-CDG	ENSEMBL:ENSG00000179085	dolichyl-phosphate mannosyltransferase subunit 3, regulatory
+ORPHANET:263487	COG5-CDG	ENSEMBL:ENSG00000164597	component of oligomeric golgi complex 5
+ORPHANET:263458	Hyperinsulinism due to INSR deficiency	ENSEMBL:ENSG00000171105	insulin receptor
+ORPHANET:263455	Hyperinsulinism due to HNF4A deficiency	ENSEMBL:ENSG00000101076	hepatocyte nuclear factor 4 alpha
+ORPHANET:1832	Lethal osteosclerotic bone dysplasia	ENSEMBL:ENSG00000177706	FAM20C golgi associated secretory pathway kinase
+ORPHANET:3019	Ramon syndrome	ENSEMBL:ENSG00000062598	engulfment and cell motility 2
+ORPHANET:263463	CHST3-related skeletal dysplasia	ENSEMBL:ENSG00000122863	carbohydrate sulfotransferase 3
+ORPHANET:263410	Infantile spasms-psychomotor retardation-progressive brain atrophy-basal ganglia disease syndrome	ENSEMBL:ENSG00000135917	solute carrier family 19 member 3
+ORPHANET:769	Rabson-Mendenhall syndrome	ENSEMBL:ENSG00000171105	insulin receptor
+ORPHANET:3005	Pyle disease	ENSEMBL:ENSG00000106483	secreted frizzled related protein 4
+ORPHANET:263347	MRCS syndrome	ENSEMBL:ENSG00000167995	bestrophin 1
+ORPHANET:263297	Glycogen storage disease with severe cardiomyopathy due to glycogenin deficiency	ENSEMBL:ENSG00000163754	glycogenin 1
+ORPHANET:3138	Ulnar-mammary syndrome	ENSEMBL:ENSG00000135111	T-box transcription factor 3
+ORPHANET:798	Schinzel-Giedion syndrome	ENSEMBL:ENSG00000152217	SET binding protein 1
+ORPHANET:3102	Richieri Costa-Pereira syndrome	ENSEMBL:ENSG00000141543	eukaryotic translation initiation factor 4A3
+ORPHANET:3109	Mayer-Rokitansky-Küster-Hauser syndrome	ENSEMBL:ENSG00000162552	Wnt family member 4
+ORPHANET:3086	Autosomal dominant vitreoretinochoroidopathy	ENSEMBL:ENSG00000167995	bestrophin 1
+ORPHANET:3088	Revesz syndrome	ENSEMBL:ENSG00000092330	TERF1 interacting nuclear factor 2
+ORPHANET:3097	Meacham syndrome	ENSEMBL:ENSG00000184937	WT1 transcription factor
+ORPHANET:3077	X-linked intellectual disability-psychosis-macroorchidism syndrome	ENSEMBL:ENSG00000169057	methyl-CpG binding protein 2
+ORPHANET:3063	X-linked intellectual disability, Snyder type	ENSEMBL:ENSG00000102172	spermine synthase
+ORPHANET:2886	TARP syndrome	ENSEMBL:ENSG00000182872	RNA binding motif protein 10
+ORPHANET:2879	Phocomelia, Schinzel type	ENSEMBL:ENSG00000154764	Wnt family member 7A
+ORPHANET:268920	Isolated megalencephaly	ENSEMBL:ENSG00000145979	TBC1 domain family member 7
+ORPHANET:268882	Arnold-Chiari malformation type I	ENSEMBL:ENSG00000107984	dickkopf WNT signaling pathway inhibitor 1
+ORPHANET:268823	Occipital encephalocele	ENSEMBL:ENSG00000165617	dishevelled binding antagonist of beta catenin 1
+ORPHANET:2874	Phakomatosis pigmentokeratotica	ENSEMBL:ENSG00000174775	HRas proto-oncogene, GTPase
+ORPHANET:2848	Camptodactyly-arthropathy-coxa-vara-pericarditis syndrome	ENSEMBL:ENSG00000116690	proteoglycan 4
+ORPHANET:2854	Fuhrmann syndrome	ENSEMBL:ENSG00000154764	Wnt family member 7A
+ORPHANET:268129	Spheroid body myopathy	ENSEMBL:ENSG00000120729	myotilin
+ORPHANET:2822	Autosomal recessive spastic paraplegia type 11	ENSEMBL:ENSG00000104133	SPG11 vesicle trafficking associated, spatacsin
+ORPHANET:268261	DYRK1A-related intellectual disability syndrome due to 21q22.13q22.2 microdeletion	ENSEMBL:ENSG00000157540	dual specificity tyrosine phosphorylation regulated kinase 1A
+ORPHANET:2833	Stiff skin syndrome	ENSEMBL:ENSG00000166147	fibrillin 1
+ORPHANET:2834	Wrinkly skin syndrome	ENSEMBL:ENSG00000185344	ATPase H+ transporting V0 subunit a2
+ORPHANET:2969	Proteus-like syndrome	ENSEMBL:ENSG00000171862	phosphatase and tensin homolog
+ORPHANET:750	Pseudoachondroplasia	ENSEMBL:ENSG00000105664	cartilage oligomeric matrix protein
+ORPHANET:2957	Guttmacher syndrome	ENSEMBL:ENSG00000106031	homeobox A13
+ORPHANET:2899	Brachyolmia-amelogenesis imperfecta syndrome	ENSEMBL:ENSG00000168056	latent transforming growth factor beta binding protein 3
+ORPHANET:2919	Orofaciodigital syndrome type 5	ENSEMBL:ENSG00000118197	DEAD-box helicase 59
+ORPHANET:3377	Trismus-pseudocamptodactyly syndrome	ENSEMBL:ENSG00000133020	myosin heavy chain 8
+ORPHANET:275786	Drug- or toxin-induced pulmonary arterial hypertension	ENSEMBL:ENSG00000204217	bone morphogenetic protein receptor type 2
+ORPHANET:275798	Pulmonary arterial hypertension associated with connective tissue disease	ENSEMBL:ENSG00000234745	major histocompatibility complex, class I, B
+ORPHANET:3363	Trichomegaly-retina pigmentary degeneration-dwarfism syndrome	ENSEMBL:ENSG00000032444	patatin like phospholipase domain containing 6
+ORPHANET:3412	VACTERL with hydrocephalus	ENSEMBL:ENSG00000181544	FA complementation group B
+ORPHANET:276152	Multiple endocrine neoplasia type 4	ENSEMBL:ENSG00000111276	cyclin dependent kinase inhibitor 1B
+ORPHANET:276066	Bile acid CoA ligase deficiency and defective amidation	ENSEMBL:ENSG00000083807	solute carrier family 27 member 5
+ORPHANET:3329	Tibial aplasia-ectrodactyly syndrome	ENSEMBL:ENSG00000205899	basic helix-loop-helix family member a9
+ORPHANET:275517	Autoimmune lymphoproliferative syndrome with recurrent viral infections	ENSEMBL:ENSG00000064012	caspase 8
+ORPHANET:3352	Tricho-dento-osseous syndrome	ENSEMBL:ENSG00000064195	distal-less homeobox 3
+ORPHANET:3342	Arterial tortuosity syndrome	ENSEMBL:ENSG00000197496	solute carrier family 2 member 10
+ORPHANET:3339	Toriello-Lacassie-Droste syndrome	ENSEMBL:ENSG00000133703	KRAS proto-oncogene, GTPase
+ORPHANET:3338	Toriello-Carey syndrome	ENSEMBL:ENSG00000215301	DEAD-box helicase 3 X-linked
+ORPHANET:3464	Woodhouse-Sakati syndrome	ENSEMBL:ENSG00000115827	DDB1 and CUL4 associated factor 17
+ORPHANET:3243	Sweet syndrome	ENSEMBL:ENSG00000103313	MEFV innate immuity regulator, pyrin
+ORPHANET:1827	Acromelic frontonasal dysplasia	ENSEMBL:ENSG00000130449	zinc finger SWIM-type containing 6
+ORPHANET:268973	Isolated focal cortical dysplasia type Ia	ENSEMBL:ENSG00000102100	solute carrier family 35 member A2
+ORPHANET:2460	Van den Ende-Gupta syndrome	ENSEMBL:ENSG00000244486	scavenger receptor class F member 2
+ORPHANET:3453	Autoimmune polyendocrinopathy type 1	ENSEMBL:ENSG00000160224	autoimmune regulator
+ORPHANET:269510	Congenital non-communicating hydrocephalus	ENSEMBL:ENSG00000015133	coiled-coil domain containing 88C
+ORPHANET:3454	Intellectual disability-developmental delay-contractures syndrome	ENSEMBL:ENSG00000126970	zinc finger C4H2-type containing
+ORPHANET:3455	Wiedemann-Rautenstrauch syndrome	ENSEMBL:ENSG00000148606	RNA polymerase III subunit A
+ORPHANET:1856	Spondyloperipheral dysplasia-short ulna syndrome	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:280333	Alpha-dystroglycan-related limb-girdle muscular dystrophy R16	ENSEMBL:ENSG00000173402	dystroglycan 1
+ORPHANET:280325	Distal monosomy 12p	ENSEMBL:ENSG00000082805	ELKS/RAB6-interacting/CAST family member 1
+ORPHANET:280293	Pelizaeus-Merzbacher-like disease due to AIMP1 mutation	ENSEMBL:ENSG00000164022	aminoacyl tRNA synthetase complex interacting multifunctional protein 1
+ORPHANET:280288	Pelizaeus-Merzbacher-like disease due to HSPD1 mutation	ENSEMBL:ENSG00000144381	heat shock protein family D (Hsp60) member 1
+ORPHANET:280365	Autosomal semi-dominant severe lipodystrophic laminopathy	ENSEMBL:ENSG00000160789	lamin A/C
+ORPHANET:3193	Supravalvular aortic stenosis	ENSEMBL:ENSG00000049540	elastin
+ORPHANET:280356	PLIN1-related familial partial lipodystrophy	ENSEMBL:ENSG00000166819	perilipin 1
+ORPHANET:280406	Familial steroid-resistant nephrotic syndrome with sensorineural deafness	ENSEMBL:ENSG00000119723	coenzyme Q6, monooxygenase
+ORPHANET:280384	Recessive intellectual disability-motor dysfunction-multiple joint contractures syndrome	ENSEMBL:ENSG00000147475	ER lipid raft associated 2
+ORPHANET:280397	Familial Alzheimer-like prion disease	ENSEMBL:ENSG00000171867	prion protein
+ORPHANET:280576	Nestor-Guillermo progeria syndrome	ENSEMBL:ENSG00000175334	BAF nuclear assembly factor 1
+ORPHANET:280586	Chondrodysplasia with joint dislocations, gPAPP type	ENSEMBL:ENSG00000104331	3'(2'), 5'-bisphosphate nucleotidase 2
+ORPHANET:280553	Fatal infantile hypertonic myofibrillar myopathy	ENSEMBL:ENSG00000109846	crystallin alpha B
+ORPHANET:280558	Warsaw breakage syndrome	ENSEMBL:ENSG00000013573	DEAD/H-box helicase 11
+ORPHANET:647	Nijmegen breakage syndrome	ENSEMBL:ENSG00000104320	nibrin
+ORPHANET:279943	Hereditary neutrophilia	ENSEMBL:ENSG00000119535	colony stimulating factor 3 receptor
+ORPHANET:279934	Mitochondrial DNA depletion syndrome, hepatocerebral form due to DGUOK deficiency	ENSEMBL:ENSG00000114956	deoxyguanosine kinase
+ORPHANET:280142	Severe combined immunodeficiency due to LCK deficiency	ENSEMBL:ENSG00000182866	LCK proto-oncogene, Src family tyrosine kinase
+ORPHANET:280133	Complement component 3 deficiency	ENSEMBL:ENSG00000125730	complement C3
+ORPHANET:3163	SHORT syndrome	ENSEMBL:ENSG00000145675	phosphoinositide-3-kinase regulatory subunit 1
+ORPHANET:1479	Atrial septal defect-atrioventricular conduction defects syndrome	ENSEMBL:ENSG00000183072	NK2 homeobox 5
+ORPHANET:280071	ALG11-CDG	ENSEMBL:ENSG00000253710	ALG11 alpha-1,2-mannosyltransferase
+ORPHANET:280210	Pelizaeus-Merzbacher disease, connatal form	ENSEMBL:ENSG00000123560	proteolipid protein 1
+ORPHANET:280219	Pelizaeus-Merzbacher disease, classic form	ENSEMBL:ENSG00000123560	proteolipid protein 1
+ORPHANET:3175	X-linked spasticity-intellectual disability-epilepsy syndrome	ENSEMBL:ENSG00000004848	aristaless related homeobox
+ORPHANET:280183	Methylmalonic aciduria due to transcobalamin receptor defect	ENSEMBL:ENSG00000167775	CD320 molecule
+ORPHANET:280282	Pelizaeus-Merzbacher-like disease due to GJC2 mutation	ENSEMBL:ENSG00000198835	gap junction protein gamma 2
+ORPHANET:280234	Null syndrome	ENSEMBL:ENSG00000123560	proteolipid protein 1
+ORPHANET:1855	Spondyloenchondrodysplasia	ENSEMBL:ENSG00000102575	acid phosphatase 5, tartrate resistant
+ORPHANET:280224	Pelizaeus-Merzbacher disease, transitional form	ENSEMBL:ENSG00000123560	proteolipid protein 1
+ORPHANET:1797	Autosomal dominant spondylocostal dysostosis	ENSEMBL:ENSG00000149922	T-box transcription factor 6
+ORPHANET:280229	Pelizaeus-Merzbacher disease in female carriers	ENSEMBL:ENSG00000123560	proteolipid protein 1
+ORPHANET:276580	Autosomal dominant hyperinsulinism due to Kir6.2 deficiency	ENSEMBL:ENSG00000187486	potassium inwardly rectifying channel subfamily J member 11
+ORPHANET:276575	Autosomal dominant hyperinsulinism due to SUR1 deficiency	ENSEMBL:ENSG00000006071	ATP binding cassette subfamily C member 8
+ORPHANET:276598	Diazoxide-resistant focal hyperinsulinism due to SUR1 deficiency	ENSEMBL:ENSG00000006071	ATP binding cassette subfamily C member 8
+ORPHANET:276603	Diazoxide-resistant focal hyperinsulinism due to Kir6.2 deficiency	ENSEMBL:ENSG00000187486	potassium inwardly rectifying channel subfamily J member 11
+ORPHANET:276630	Symptomatic form of Coffin-Lowry syndrome in female carriers	ENSEMBL:ENSG00000177189	ribosomal protein S6 kinase A3
+ORPHANET:276198	Spinocerebellar ataxia type 36	ENSEMBL:ENSG00000101361	NOP56 ribonucleoprotein
+ORPHANET:276193	Spinocerebellar ataxia type 35	ENSEMBL:ENSG00000166948	transglutaminase 6
+ORPHANET:3226	Deafness-lymphedema-leukemia syndrome	ENSEMBL:ENSG00000179348	GATA binding protein 2
+ORPHANET:276238	Machado-Joseph disease type 1	ENSEMBL:ENSG00000066427	ataxin 3
+ORPHANET:276223	Mucopolysaccharidosis type 6, slowly progressing	ENSEMBL:ENSG00000113273	arylsulfatase B
+ORPHANET:276212	Mucopolysaccharidosis type 6, rapidly progressing	ENSEMBL:ENSG00000113273	arylsulfatase B
+ORPHANET:276244	Machado-Joseph disease type 3	ENSEMBL:ENSG00000066427	ataxin 3
+ORPHANET:276241	Machado-Joseph disease type 2	ENSEMBL:ENSG00000066427	ataxin 3
+ORPHANET:276280	Hemihyperplasia-multiple lipomatosis syndrome	ENSEMBL:ENSG00000121879	phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunit alpha
+ORPHANET:3238	Cardiospondylocarpofacial syndrome	ENSEMBL:ENSG00000135341	mitogen-activated protein kinase kinase kinase 7
+ORPHANET:276271	NON RARE IN EUROPE: Familial dysalbuminemic hyperthyroxinemia	ENSEMBL:ENSG00000163631	albumin
+ORPHANET:276405	Hyperbiliverdinemia	ENSEMBL:ENSG00000106605	biliverdin reductase A
+ORPHANET:3255	Filippi syndrome	ENSEMBL:ENSG00000169607	cytoskeleton associated protein 2 like
+ORPHANET:276556	Hyperinsulinism due to UCP2 deficiency	ENSEMBL:ENSG00000175567	uncoupling protein 2
+ORPHANET:276432	Ogden syndrome	ENSEMBL:ENSG00000102030	N-alpha-acetyltransferase 10, NatA catalytic subunit
+ORPHANET:3253	Cleft lip/palate-ectodermal dysplasia syndrome	ENSEMBL:ENSG00000110400	nectin cell adhesion molecule 1
+ORPHANET:276435	Lower motor neuron syndrome with late-adult onset	ENSEMBL:ENSG00000250479	coiled-coil-helix-coiled-coil-helix domain containing 10
+ORPHANET:911	Combined immunodeficiency due to ZAP70 deficiency	ENSEMBL:ENSG00000115085	zeta chain of T-cell receptor associated protein kinase 70
+ORPHANET:943	Malonic aciduria	ENSEMBL:ENSG00000103150	malonyl-CoA decarboxylase
+ORPHANET:2089	Glycogen storage disease due to hepatic glycogen synthase deficiency	ENSEMBL:ENSG00000111713	glycogen synthase 2
+ORPHANET:412	Dysbetalipoproteinemia	ENSEMBL:ENSG00000130203	apolipoprotein E
+ORPHANET:743	Severe hereditary thrombophilia due to congenital protein S deficiency	ENSEMBL:ENSG00000184500	protein S
+ORPHANET:424	Familial hyperthyroidism due to mutations in TSH receptor	ENSEMBL:ENSG00000165409	thyroid stimulating hormone receptor
+ORPHANET:325	Congenital factor II deficiency	ENSEMBL:ENSG00000180210	coagulation factor II, thrombin
+ORPHANET:343	Hyperimmunoglobulinemia D with periodic fever	ENSEMBL:ENSG00000110921	mevalonate kinase
+ORPHANET:158	Systemic primary carnitine deficiency	ENSEMBL:ENSG00000197375	solute carrier family 22 member 5
+ORPHANET:2056	Essential fructosuria	ENSEMBL:ENSG00000138030	ketohexokinase
+ORPHANET:820	Sneddon syndrome	ENSEMBL:ENSG00000093072	adenosine deaminase 2
+ORPHANET:832	Succinyl-CoA:3-oxoacid CoA transferase deficiency	ENSEMBL:ENSG00000083720	3-oxoacid CoA-transferase 1
+ORPHANET:20	3-hydroxy-3-methylglutaric aciduria	ENSEMBL:ENSG00000117305	3-hydroxy-3-methylglutaryl-CoA lyase
+ORPHANET:714	Hemolytic anemia due to diphosphoglycerate mutase deficiency	ENSEMBL:ENSG00000172331	bisphosphoglycerate mutase
+ORPHANET:712	Hemolytic anemia due to glucophosphate isomerase deficiency	ENSEMBL:ENSG00000105220	glucose-6-phosphate isomerase
+ORPHANET:206546	Symptomatic form of muscular dystrophy of Duchenne and Becker in female carriers	ENSEMBL:ENSG00000198947	dystrophin
+ORPHANET:206554	Fukutin-related limb-girdle muscular dystrophy R13	ENSEMBL:ENSG00000106692	fukutin
+ORPHANET:206549	Anoctamin-5-related limb-girdle muscular dystrophy R12	ENSEMBL:ENSG00000171714	anoctamin 5
+ORPHANET:206564	POMGNT1-related limb-girdle muscular dystrophy R15	ENSEMBL:ENSG00000085998	protein O-linked mannose N-acetylglucosaminyltransferase 1 (beta 1,2-)
+ORPHANET:206559	POMT2-related limb-girdle muscular dystrophy R14	ENSEMBL:ENSG00000009830	protein O-mannosyltransferase 2
+ORPHANET:206580	Autosomal recessive lower motor neuron disease with childhood onset	ENSEMBL:ENSG00000171680	pleckstrin homology and RhoGEF domain containing G5
+ORPHANET:206443	Late-infantile/juvenile Krabbe disease	ENSEMBL:ENSG00000054983	galactosylceramidase
+ORPHANET:206448	Adult Krabbe disease	ENSEMBL:ENSG00000054983	galactosylceramidase
+ORPHANET:633	Laron syndrome	ENSEMBL:ENSG00000112964	growth hormone receptor
+ORPHANET:229	Familial aortic dissection	ENSEMBL:ENSG00000133392	myosin heavy chain 11
+ORPHANET:766	Hemolytic anemia due to red cell pyruvate kinase deficiency	ENSEMBL:ENSG00000143627	pyruvate kinase L/R
+ORPHANET:206599	Isolated asymptomatic elevation of creatine phosphokinase	ENSEMBL:ENSG00000182533	caveolin 3
+ORPHANET:3206	Stüve-Wiedemann syndrome	ENSEMBL:ENSG00000113594	LIF receptor subunit alpha
+ORPHANET:206583	Adult polyglucosan body disease	ENSEMBL:ENSG00000114480	1,4-alpha-glucan branching enzyme 1
+ORPHANET:1272	Aymé-Gripp syndrome	ENSEMBL:ENSG00000178573	MAF bZIP transcription factor
+ORPHANET:208513	Spinocerebellar ataxia type 29	ENSEMBL:ENSG00000150995	inositol 1,4,5-trisphosphate receptor type 1
+ORPHANET:208447	Bilateral generalized polymicrogyria	ENSEMBL:ENSG00000176884	glutamate ionotropic receptor NMDA type subunit 1
+ORPHANET:3051	Nicolaides-Baraitser syndrome	ENSEMBL:ENSG00000080503	SWI/SNF related, matrix associated, actin dependent regulator of chromatin, subfamily a, member 2
+ORPHANET:208441	Bilateral parasagittal parieto-occipital polymicrogyria	ENSEMBL:ENSG00000112367	FIG4 phosphoinositide 5-phosphatase
+ORPHANET:2963	Progeroid syndrome, Petty type	ENSEMBL:ENSG00000085491	solute carrier family 25 member 24
+ORPHANET:1541	Craniosynostosis, Boston type	ENSEMBL:ENSG00000120149	msh homeobox 2
+ORPHANET:2151	Hirschsprung disease-ganglioneuroblastoma syndrome	ENSEMBL:ENSG00000109132	paired like homeobox 2B
+ORPHANET:209335	Autosomal dominant adult-onset proximal spinal muscular atrophy	ENSEMBL:ENSG00000124164	VAMP associated protein B and C
+ORPHANET:209341	DYNC1H1-related autosomal dominant childhood-onset proximal spinal muscular atrophy	ENSEMBL:ENSG00000197102	dynein cytoplasmic 1 heavy chain 1
+ORPHANET:210115	Sterile multifocal osteomyelitis with periostitis and pustulosis	ENSEMBL:ENSG00000136689	interleukin 1 receptor antagonist
+ORPHANET:209981	IRIDA syndrome	ENSEMBL:ENSG00000187045	transmembrane serine protease 6
+ORPHANET:210122	Congenital alveolar capillary dysplasia	ENSEMBL:ENSG00000103241	forkhead box F1
+ORPHANET:210128	Urocanic aciduria	ENSEMBL:ENSG00000159650	urocanate hydratase 1
+ORPHANET:209951	Autosomal recessive spastic paraplegia type 18	ENSEMBL:ENSG00000147475	ER lipid raft associated 2
+ORPHANET:209967	Episodic ataxia type 6	ENSEMBL:ENSG00000079215	solute carrier family 1 member 3
+ORPHANET:209908	Isolated childhood apraxia of speech	ENSEMBL:ENSG00000128573	forkhead box P2
+ORPHANET:209905	Brain-lung-thyroid syndrome	ENSEMBL:ENSG00000136352	NK2 homeobox 1
+ORPHANET:209902	Hypercholesterolemia due to cholesterol 7alpha-hydroxylase deficiency	ENSEMBL:ENSG00000167910	cytochrome P450 family 7 subfamily A member 1
+ORPHANET:209893	NON RARE IN EUROPE: Congenital isolated thyroxine-binding globulin deficiency	ENSEMBL:ENSG00000123561	serpin family A member 7
+ORPHANET:209932	Cone dystrophy with supernormal rod response	ENSEMBL:ENSG00000168263	potassium voltage-gated channel modifier subfamily V member 2
+ORPHANET:209370	Severe neonatal-onset encephalopathy with microcephaly	ENSEMBL:ENSG00000169057	methyl-CpG binding protein 2
+ORPHANET:209867	Autosomal dominant rhegmatogenous retinal detachment	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:210571	Dystonia 16	ENSEMBL:ENSG00000180228	protein activator of interferon induced protein kinase EIF2AK2
+ORPHANET:210163	Congenital lethal myopathy, Compton-North type	ENSEMBL:ENSG00000018236	contactin 1
+ORPHANET:210144	Lethal polymalformative syndrome, Boissel type	ENSEMBL:ENSG00000140718	FTO alpha-ketoglutarate dependent dioxygenase
+ORPHANET:1063	Tufted angioma	ENSEMBL:ENSG00000156049	G protein subunit alpha 14
+ORPHANET:211067	Episodic ataxia type 5	ENSEMBL:ENSG00000182389	calcium voltage-gated channel auxiliary subunit beta 4
+ORPHANET:2122	Kaposiform hemangioendothelioma	ENSEMBL:ENSG00000156049	G protein subunit alpha 14
+ORPHANET:220	Denys-Drash syndrome	ENSEMBL:ENSG00000184937	WT1 transcription factor
+ORPHANET:5	Long chain 3-hydroxyacyl-CoA dehydrogenase deficiency	ENSEMBL:ENSG00000084754	hydroxyacyl-CoA dehydrogenase trifunctional multienzyme complex subunit alpha
+ORPHANET:25	Glutaryl-CoA dehydrogenase deficiency	ENSEMBL:ENSG00000105607	glutaryl-CoA dehydrogenase
+ORPHANET:818	Smith-Lemli-Opitz syndrome	ENSEMBL:ENSG00000172893	7-dehydrocholesterol reductase
+ORPHANET:213504	Adenocarcinoma of ovary	ENSEMBL:ENSG00000122641	inhibin subunit beta A
+ORPHANET:175	Cartilage-hair hypoplasia	ENSEMBL:ENSG00000277027	RNA component of mitochondrial RNA processing endoribonuclease
+ORPHANET:42	Medium chain acyl-CoA dehydrogenase deficiency	ENSEMBL:ENSG00000117054	acyl-CoA dehydrogenase medium chain
+ORPHANET:2066	Gamma-aminobutyric acid transaminase deficiency	ENSEMBL:ENSG00000183044	4-aminobutyrate aminotransferase
+ORPHANET:2849	Perlman syndrome	ENSEMBL:ENSG00000144535	DIS3 like 3'-5' exoribonuclease 2
+ORPHANET:747	Autoimmune pulmonary alveolar proteinosis	ENSEMBL:ENSG00000196126	major histocompatibility complex, class II, DR beta 1
+ORPHANET:216729	Congenitally uncorrected transposition of the great arteries with cardiac malformation	ENSEMBL:ENSG00000136698	cripto, FRL-1, cryptic family 1
+ORPHANET:882	Tyrosinemia type 1	ENSEMBL:ENSG00000103876	fumarylacetoacetate hydrolase
+ORPHANET:216828	Osteogenesis imperfecta type 5	ENSEMBL:ENSG00000206013	interferon induced transmembrane protein 5
+ORPHANET:3474	CHIME syndrome	ENSEMBL:ENSG00000108474	phosphatidylinositol glycan anchor biosynthesis class L
+ORPHANET:216866	Classic pantothenate kinase-associated neurodegeneration	ENSEMBL:ENSG00000125779	pantothenate kinase 2
+ORPHANET:216873	Atypical pantothenate kinase-associated neurodegeneration	ENSEMBL:ENSG00000125779	pantothenate kinase 2
+ORPHANET:217012	Spinocerebellar ataxia type 31	ENSEMBL:ENSG00000166546	brain expressed associated with NEDD4 1
+ORPHANET:2088	Fanconi-Bickel syndrome	ENSEMBL:ENSG00000163581	solute carrier family 2 member 2
+ORPHANET:217031	NON RARE IN EUROPE: Obesity due to MC3R deficiency	ENSEMBL:ENSG00000124089	melanocortin 3 receptor
+ORPHANET:217266	BNAR syndrome	ENSEMBL:ENSG00000164946	FRAS1 related extracellular matrix 1
+ORPHANET:179	Birdshot chorioretinopathy	ENSEMBL:ENSG00000206503	major histocompatibility complex, class I, A
+ORPHANET:217093	Mucopolysaccharidosis type 2, attenuated form	ENSEMBL:ENSG00000010404	iduronate 2-sulfatase
+ORPHANET:217085	Mucopolysaccharidosis type 2, severe form	ENSEMBL:ENSG00000010404	iduronate 2-sulfatase
+ORPHANET:1451	CINCA syndrome	ENSEMBL:ENSG00000162711	NLR family pyrin domain containing 3
+ORPHANET:217059	Isolated congenital digital clubbing	ENSEMBL:ENSG00000164120	15-hydroxyprostaglandin dehydrogenase
+ORPHANET:217055	Autosomal recessive intermediate Charcot-Marie-Tooth disease type A	ENSEMBL:ENSG00000104381	ganglioside induced differentiation associated protein 1
+ORPHANET:217335	RIN2 syndrome	ENSEMBL:ENSG00000132669	Ras and Rab interactor 2
+ORPHANET:2745	Opitz GBBB syndrome	ENSEMBL:ENSG00000101871	midline 1
+ORPHANET:217330	REN-related autosomal dominant tubulointerstitial kidney disease	ENSEMBL:ENSG00000143839	renin
+ORPHANET:1171	Cerebellar ataxia-areflexia-pes cavus-optic atrophy-sensorineural hearing loss syndrome	ENSEMBL:ENSG00000105409	ATPase Na+/K+ transporting subunit alpha 3
+ORPHANET:217566	Chronic respiratory distress with surfactant metabolism deficiency	ENSEMBL:ENSG00000168484	surfactant protein C
+ORPHANET:217563	Neonatal acute respiratory distress due to SP-B deficiency	ENSEMBL:ENSG00000168878	surfactant protein B
+ORPHANET:217407	Hereditary hypotrichosis with recurrent skin vesicles	ENSEMBL:ENSG00000134762	desmocollin 3
+ORPHANET:217467	Hereditary thrombophilia due to congenital histidine-rich (poly-L) glycoprotein deficiency	ENSEMBL:ENSG00000113905	histidine rich glycoprotein
+ORPHANET:217390	Combined immunodeficiency due to DOCK8 deficiency	ENSEMBL:ENSG00000107099	dedicator of cytokinesis 8
+ORPHANET:217396	Progressive polyneuropathy with bilateral striatal necrosis	ENSEMBL:ENSG00000125454	solute carrier family 25 member 19
+ORPHANET:217371	Acute infantile liver failure due to synthesis defect of mtDNA-encoded proteins	ENSEMBL:ENSG00000100416	tRNA mitochondrial 2-thiouridylase
+ORPHANET:217382	Neurodegenerative syndrome due to cerebral folate transport deficiency	ENSEMBL:ENSG00000110195	folate receptor 1
+ORPHANET:217377	Microduplication Xp11.22p11.23 syndrome	ENSEMBL:ENSG00000124313	IQ motif and Sec7 domain ArfGEF 2
+ORPHANET:217622	Sensorineural deafness with dilated cardiomyopathy	ENSEMBL:ENSG00000112319	EYA transcriptional coactivator and phosphatase 4
+ORPHANET:159	Carnitine-acylcarnitine translocase deficiency	ENSEMBL:ENSG00000178537	solute carrier family 25 member 20
+ORPHANET:79	Congenital alpha2-antiplasmin deficiency	ENSEMBL:ENSG00000167711	serpin family F member 2
+ORPHANET:2157	Histidinemia	ENSEMBL:ENSG00000084110	histidine ammonia-lyase
+ORPHANET:3124	Saccharopinuria	ENSEMBL:ENSG00000008311	aminoadipate-semialdehyde synthase
+ORPHANET:220407	Limited systemic sclerosis	ENSEMBL:ENSG00000196126	major histocompatibility complex, class II, DR beta 1
+ORPHANET:2203	Hyperlysinemia	ENSEMBL:ENSG00000008311	aminoadipate-semialdehyde synthase
+ORPHANET:332	Congenital intrinsic factor deficiency	ENSEMBL:ENSG00000134812	cobalamin binding intrinsic factor
+ORPHANET:220436	Quebec platelet disorder	ENSEMBL:ENSG00000122861	plasminogen activator, urokinase
+ORPHANET:2195	Dicarboxylic aminoaciduria	ENSEMBL:ENSG00000106688	solute carrier family 1 member 1
+ORPHANET:220443	Bleeding diathesis due to thromboxane synthesis deficiency	ENSEMBL:ENSG00000006638	thromboxane A2 receptor
+ORPHANET:2170	Methylcobalamin deficiency type cblG	ENSEMBL:ENSG00000116984	5-methyltetrahydrofolate-homocysteine methyltransferase
+ORPHANET:414	Gyrate atrophy of choroid and retina	ENSEMBL:ENSG00000065154	ornithine aminotransferase
+ORPHANET:927	Hyperammonemia due to N-acetylglutamate synthase deficiency	ENSEMBL:ENSG00000161653	N-acetylglutamate synthase
+ORPHANET:941	D-glyceric aciduria	ENSEMBL:ENSG00000168237	glycerate kinase
+ORPHANET:220465	Laron syndrome with immunodeficiency	ENSEMBL:ENSG00000173757	signal transducer and activator of transcription 5B
+ORPHANET:2843	Pentosuria	ENSEMBL:ENSG00000169738	dicarbonyl and L-xylulose reductase
+ORPHANET:212	Cystathioninuria	ENSEMBL:ENSG00000116761	cystathionine gamma-lyase
+ORPHANET:470	Lysinuric protein intolerance	ENSEMBL:ENSG00000155465	solute carrier family 7 member 7
+ORPHANET:1578	Pterin-4 alpha-carbinolamine dehydratase deficiency	ENSEMBL:ENSG00000166228	pterin-4 alpha-carbinolamine dehydratase 1
+ORPHANET:221008	Rothmund-Thomson syndrome type 1	ENSEMBL:ENSG00000153107	anaphase promoting complex subunit 1
+ORPHANET:24	Fumaric aciduria	ENSEMBL:ENSG00000091483	fumarate hydratase
+ORPHANET:221016	Rothmund-Thomson syndrome type 2	ENSEMBL:ENSG00000160957	RecQ like helicase 4
+ORPHANET:851	Paris-Trousseau thrombocytopenia	ENSEMBL:ENSG00000151702	Fli-1 proto-oncogene, ETS transcription factor
+ORPHANET:221043	Hereditary fibrosing poikiloderma-tendon contractures-myopathy-pulmonary fibrosis syndrome	ENSEMBL:ENSG00000189057	FAM111 trypsin like peptidase B
+ORPHANET:221046	Poikiloderma with neutropenia	ENSEMBL:ENSG00000103005	U6 snRNA biogenesis phosphodiesterase 1
+ORPHANET:745	Severe hereditary thrombophilia due to congenital protein C deficiency	ENSEMBL:ENSG00000115718	protein C, inactivator of coagulation factors Va and VIIIa
+ORPHANET:225123	Hemochromatosis type 3	ENSEMBL:ENSG00000106327	transferrin receptor 2
+ORPHANET:221126	Fowler vasculopathy	ENSEMBL:ENSG00000119686	FLVCR heme transporter 2
+ORPHANET:228003	Severe combined immunodeficiency due to CORO1A deficiency	ENSEMBL:ENSG00000102879	coronin 1A
+ORPHANET:228000	Idiopathic CD4 lymphocytopenia	ENSEMBL:ENSG00000109103	unc-119 lipid binding chaperone
+ORPHANET:842	Testicular seminomatous germ cell tumor	ENSEMBL:ENSG00000157404	KIT proto-oncogene, receptor tyrosine kinase
+ORPHANET:227976	Autosomal recessive optic atrophy, OPA7 type	ENSEMBL:ENSG00000171202	transmembrane protein 126A
+ORPHANET:228012	Progressive sensorineural hearing loss-hypertrophic cardiomyopathy syndrome	ENSEMBL:ENSG00000196586	myosin VI
+ORPHANET:543	Burkitt lymphoma	ENSEMBL:ENSG00000136997	MYC proto-oncogene, bHLH transcription factor
+ORPHANET:227510	Multiple system atrophy, cerebellar type	ENSEMBL:ENSG00000173085	coenzyme Q2, polyprenyltransferase
+ORPHANET:419	Hyperprolinemia type 1	ENSEMBL:ENSG00000100033	proline dehydrogenase 1
+ORPHANET:226316	Genetic transient congenital hypothyroidism	ENSEMBL:ENSG00000140279	dual oxidase 2
+ORPHANET:503	Larsen syndrome	ENSEMBL:ENSG00000136068	filamin B
+ORPHANET:228423	Monocytopenia with susceptibility to infections	ENSEMBL:ENSG00000179348	GATA binding protein 2
+ORPHANET:228415	5q35 microduplication syndrome	ENSEMBL:ENSG00000165671	nuclear receptor binding SET domain protein 1
+ORPHANET:132	Butyrylcholinesterase deficiency	ENSEMBL:ENSG00000114200	butyrylcholinesterase
+ORPHANET:228426	Syndromic multisystem autoimmune disease due to Itch deficiency	ENSEMBL:ENSG00000078747	itchy E3 ubiquitin protein ligase
+ORPHANET:228387	Spondylo-megaepiphyseal-metaphyseal dysplasia	ENSEMBL:ENSG00000109705	NK3 homeobox 2
+ORPHANET:228390	Frontonasal dysplasia-alopecia-genital anomalies syndrome	ENSEMBL:ENSG00000052850	ALX homeobox 4
+ORPHANET:228402	2q23.1 microdeletion syndrome	ENSEMBL:ENSG00000204406	methyl-CpG binding domain protein 5
+ORPHANET:228366	CLN7 disease	ENSEMBL:ENSG00000164073	major facilitator superfamily domain containing 8
+ORPHANET:228363	CLN6 disease	ENSEMBL:ENSG00000128973	CLN6 transmembrane ER protein
+ORPHANET:228360	CLN5 disease	ENSEMBL:ENSG00000102805	CLN5 intracellular trafficking protein
+ORPHANET:228384	5q14.3 microdeletion syndrome	ENSEMBL:ENSG00000081189	myocyte enhancer factor 2C
+ORPHANET:228374	Charcot-Marie-Tooth disease type 2B5	ENSEMBL:ENSG00000277586	neurofilament light chain
+ORPHANET:228340	CLN4A disease	ENSEMBL:ENSG00000128973	CLN6 transmembrane ER protein
+ORPHANET:228337	CLN10 disease	ENSEMBL:ENSG00000117984	cathepsin D
+ORPHANET:228329	CLN1 disease	ENSEMBL:ENSG00000131238	palmitoyl-protein thioesterase 1
+ORPHANET:228354	CLN8 disease	ENSEMBL:ENSG00000182372	CLN8 transmembrane ER and ERGIC protein
+ORPHANET:228349	CLN2 disease	ENSEMBL:ENSG00000166340	tripeptidyl peptidase 1
+ORPHANET:228346	CLN3 disease	ENSEMBL:ENSG00000188603	CLN3 lysosomal/endosomal transmembrane protein, battenin
+ORPHANET:228343	CLN4B disease	ENSEMBL:ENSG00000101152	DnaJ heat shock protein family (Hsp40) member C5
+ORPHANET:228302	Carnitine palmitoyl transferase II deficiency, myopathic form	ENSEMBL:ENSG00000157184	carnitine palmitoyltransferase 2
+ORPHANET:228305	Carnitine palmitoyl transferase II deficiency, severe infantile form	ENSEMBL:ENSG00000157184	carnitine palmitoyltransferase 2
+ORPHANET:228308	Carnitine palmitoyl transferase II deficiency, neonatal form	ENSEMBL:ENSG00000157184	carnitine palmitoyltransferase 2
+ORPHANET:3203	Overhydrated hereditary stomatocytosis	ENSEMBL:ENSG00000112077	Rh associated glycoprotein
+ORPHANET:328	Congenital factor X deficiency	ENSEMBL:ENSG00000126218	coagulation factor X
+ORPHANET:228174	Autosomal dominant Charcot-Marie-Tooth disease type 2N	ENSEMBL:ENSG00000090861	alanyl-tRNA synthetase 1
+ORPHANET:228169	Autosomal dominant striatal neurodegeneration	ENSEMBL:ENSG00000113231	phosphodiesterase 8B
+ORPHANET:2132	Hemoglobin C disease	ENSEMBL:ENSG00000244734	hemoglobin subunit beta
+ORPHANET:2133	Hemoglobin E disease	ENSEMBL:ENSG00000244734	hemoglobin subunit beta
+ORPHANET:228179	Autosomal dominant Charcot-Marie-Tooth disease type 2M	ENSEMBL:ENSG00000079805	dynamin 2
+ORPHANET:751	NON RARE IN EUROPE: Pseudoarylsulfatase A deficiency	ENSEMBL:ENSG00000100299	arylsulfatase A
+ORPHANET:231401	Alpha-thalassemia-myelodysplastic syndrome	ENSEMBL:ENSG00000085224	ATRX chromatin remodeler
+ORPHANET:231393	Beta-thalassemia-X-linked thrombocytopenia syndrome	ENSEMBL:ENSG00000102145	GATA binding protein 1
+ORPHANET:1309	Medullary sponge kidney	ENSEMBL:ENSG00000275410	HNF1 homeobox B
+ORPHANET:231249	Hemoglobin E-beta-thalassemia syndrome	ENSEMBL:ENSG00000244734	hemoglobin subunit beta
+ORPHANET:231242	Hemoglobin C-beta-thalassemia syndrome	ENSEMBL:ENSG00000244734	hemoglobin subunit beta
+ORPHANET:2197	Idiopathic hypercalciuria	ENSEMBL:ENSG00000143199	adenylate cyclase 10
+ORPHANET:231226	Dominant beta-thalassemia	ENSEMBL:ENSG00000244734	hemoglobin subunit beta
+ORPHANET:231222	Beta-thalassemia intermedia	ENSEMBL:ENSG00000244734	hemoglobin subunit beta
+ORPHANET:231214	Beta-thalassemia major	ENSEMBL:ENSG00000244734	hemoglobin subunit beta
+ORPHANET:2841	Familial benign chronic pemphigus	ENSEMBL:ENSG00000017260	ATPase secretory pathway Ca2+ transporting 1
+ORPHANET:347	Frasier syndrome	ENSEMBL:ENSG00000184937	WT1 transcription factor
+ORPHANET:231154	Combined immunodeficiency due to partial RAG1 deficiency	ENSEMBL:ENSG00000166349	recombination activating 1
+ORPHANET:2596	Myopathy and diabetes mellitus	ENSEMBL:ENSG00000210194	mitochondrially encoded tRNA-Glu (GAA/G)
+ORPHANET:2966	Properdin deficiency	ENSEMBL:ENSG00000126759	complement factor properdin
+ORPHANET:231120	Beckwith-Wiedemann syndrome due to CDKN1C mutation	ENSEMBL:ENSG00000129757	cyclin dependent kinase inhibitor 1C
+ORPHANET:231127	Beckwith-Wiedemann syndrome due to 11p15 microdeletion	ENSEMBL:ENSG00000130600	H19 imprinted maternally expressed transcript
+ORPHANET:231040	Familial generalized lentiginosis	ENSEMBL:ENSG00000111961	SAM and SH3 domain containing 1
+ORPHANET:230851	Cardiac-valvular Ehlers-Danlos syndrome	ENSEMBL:ENSG00000164692	collagen type I alpha 2 chain
+ORPHANET:82	Hereditary thrombophilia due to congenital antithrombin deficiency	ENSEMBL:ENSG00000117601	serpin family C member 1
+ORPHANET:230839	Classical-like Ehlers-Danlos syndrome type 1	ENSEMBL:ENSG00000168477	tenascin XB
+ORPHANET:238269	AApoAII amyloidosis	ENSEMBL:ENSG00000158874	apolipoprotein A2
+ORPHANET:238446	15q11q13 microduplication syndrome	ENSEMBL:ENSG00000114062	ubiquitin protein ligase E3A
+ORPHANET:238329	Severe X-linked mitochondrial encephalomyopathy	ENSEMBL:ENSG00000156709	apoptosis inducing factor mitochondria associated 1
+ORPHANET:231568	Autosomal dominant generalized dystrophic epidermolysis bullosa	ENSEMBL:ENSG00000114270	collagen type VII alpha 1 chain
+ORPHANET:1900	Kyphoscoliotic Ehlers-Danlos syndrome due to lysyl hydroxylase 1 deficiency	ENSEMBL:ENSG00000083444	procollagen-lysine,2-oxoglutarate 5-dioxygenase 1
+ORPHANET:286	Vascular Ehlers-Danlos syndrome	ENSEMBL:ENSG00000168542	collagen type III alpha 1 chain
+ORPHANET:257	Epidermolysis bullosa simplex with muscular dystrophy	ENSEMBL:ENSG00000178209	plectin
+ORPHANET:231720	Non-acquired combined pituitary hormone deficiency-sensorineural hearing loss-spine abnormalities syndrome	ENSEMBL:ENSG00000107187	LIM homeobox 3
+ORPHANET:839	Congenital nephrotic syndrome, Finnish type	ENSEMBL:ENSG00000161270	NPHS1 adhesion molecule, nephrin
+ORPHANET:452	X-linked lissencephaly with abnormal genitalia	ENSEMBL:ENSG00000004848	aristaless related homeobox
+ORPHANET:238763	Glaucoma secondary to spherophakia/ectopia lentis and megalocornea	ENSEMBL:ENSG00000119681	latent transforming growth factor beta binding protein 2
+ORPHANET:238769	1q44 microdeletion syndrome	ENSEMBL:ENSG00000153187	heterogeneous nuclear ribonucleoprotein U
+ORPHANET:238505	Combined immunodeficiency due to CD27 deficiency	ENSEMBL:ENSG00000139193	CD27 molecule
+ORPHANET:238455	Infantile dystonia-parkinsonism	ENSEMBL:ENSG00000142319	solute carrier family 6 member 3
+ORPHANET:238459	SLC35A1-CDG	ENSEMBL:ENSG00000164414	solute carrier family 35 member A1
+ORPHANET:238578	Familial clubfoot due to 17q23.1q23.2 microduplication	ENSEMBL:ENSG00000121075	T-box transcription factor 4
+ORPHANET:238557	Chuvash erythrocytosis	ENSEMBL:ENSG00000134086	von Hippel-Lindau tumor suppressor
+ORPHANET:238613	Beckwith-Wiedemann syndrome due to NSD1 mutation	ENSEMBL:ENSG00000165671	nuclear receptor binding SET domain protein 1
+ORPHANET:238670	Isolated thyrotropin-releasing hormone deficiency	ENSEMBL:ENSG00000170893	thyrotropin releasing hormone
+ORPHANET:240071	Classic progressive supranuclear palsy syndrome	ENSEMBL:ENSG00000186868	microtubule associated protein tau
+ORPHANET:240112	Progressive supranuclear palsy-progressive non-fluent aphasia syndrome	ENSEMBL:ENSG00000186868	microtubule associated protein tau
+ORPHANET:240103	Progressive supranuclear palsy-corticobasal syndrome	ENSEMBL:ENSG00000186868	microtubule associated protein tau
+ORPHANET:240094	Progressive supranuclear palsy-pure akinesia with gait freezing syndrome	ENSEMBL:ENSG00000186868	microtubule associated protein tau
+ORPHANET:240085	Progressive supranuclear palsy-parkinsonism syndrome	ENSEMBL:ENSG00000186868	microtubule associated protein tau
+ORPHANET:331226	Susceptibility to infection due to TYK2 deficiency	ENSEMBL:ENSG00000105397	tyrosine kinase 2
+ORPHANET:331176	Autosomal recessive severe congenital neutropenia due to G6PC3 deficiency	ENSEMBL:ENSG00000141349	glucose-6-phosphatase catalytic subunit 3
+ORPHANET:331187	Immunodeficiency due to MASP-2 deficiency	ENSEMBL:ENSG00000009724	MBL associated serine protease 2
+ORPHANET:331190	Immunodeficiency due to ficolin3 deficiency	ENSEMBL:ENSG00000142748	ficolin 3
+ORPHANET:330050	DNM1L-related encephalopathy due to mitochondrial and peroxisomal fission defect	ENSEMBL:ENSG00000087470	dynamin 1 like
+ORPHANET:330054	Congenital cataract-progressive muscular hypotonia-hearing loss-developmental delay syndrome	ENSEMBL:ENSG00000127554	growth factor, augmenter of liver regeneration
+ORPHANET:329802	5p13 microduplication syndrome	ENSEMBL:ENSG00000164190	NIPBL cohesin loading factor
+ORPHANET:329475	Spastic paraplegia-Paget disease of bone syndrome	ENSEMBL:ENSG00000165280	valosin containing protein
+ORPHANET:329481	Lipoprotein glomerulopathy	ENSEMBL:ENSG00000130203	apolipoprotein E
+ORPHANET:329478	Adult-onset distal myopathy due to VCP mutation	ENSEMBL:ENSG00000165280	valosin containing protein
+ORPHANET:329308	Fatty acid hydroxylase-associated neurodegeneration	ENSEMBL:ENSG00000103089	fatty acid 2-hydroxylase
+ORPHANET:329314	Adult-onset multiple mitochondrial DNA deletion syndrome due to DGUOK deficiency	ENSEMBL:ENSG00000114956	deoxyguanosine kinase
+ORPHANET:329319	Thrombocythemia with distal limb defects	ENSEMBL:ENSG00000090534	thrombopoietin
+ORPHANET:329284	Beta-propeller protein-associated neurodegeneration	ENSEMBL:ENSG00000196998	WD repeat domain 45
+ORPHANET:329457	Distal arthrogryposis type 5D	ENSEMBL:ENSG00000171551	endothelin converting enzyme like 1
+ORPHANET:329466	Autosomal dominant focal dystonia, DYT25 type	ENSEMBL:ENSG00000141404	G protein subunit alpha L
+ORPHANET:329228	Microcephalic primordial dwarfism due to ZNF335 deficiency	ENSEMBL:ENSG00000198026	zinc finger protein 335
+ORPHANET:329224	Intellectual disability-craniofacial dysmorphism-cryptorchidism syndrome	ENSEMBL:ENSG00000175115	phosphofurin acidic cluster sorting protein 1
+ORPHANET:329211	Autosomal dominant neovascular inflammatory vitreoretinopathy	ENSEMBL:ENSG00000149260	calpain 5
+ORPHANET:329195	Developmental delay with autism spectrum disorder and gait instability	ENSEMBL:ENSG00000128731	HECT and RLD domain containing E3 ubiquitin protein ligase 2
+ORPHANET:329191	Tall stature-long halluces-multiple extra-epiphyses syndrome	ENSEMBL:ENSG00000159899	natriuretic peptide receptor 2
+ORPHANET:329178	Congenital muscular dystrophy with intellectual disability and severe epilepsy	ENSEMBL:ENSG00000136908	dolichyl-phosphate mannosyltransferase subunit 2, regulatory
+ORPHANET:329258	Autosomal dominant Charcot-Marie-Tooth disease type 2Q	ENSEMBL:ENSG00000181192	dehydrogenase E1 and transketolase domain containing 1
+ORPHANET:329249	Severe early-onset obesity-insulin resistance syndrome due to SH2B1 deficiency	ENSEMBL:ENSG00000178188	SH2B adaptor protein 1
+ORPHANET:329235	X-linked central congenital hypothyroidism with late-onset testicular enlargement	ENSEMBL:ENSG00000147255	immunoglobulin superfamily member 1
+ORPHANET:329	Congenital factor XI deficiency	ENSEMBL:ENSG00000088926	coagulation factor XI
+ORPHANET:1243	Best vitelliform macular dystrophy	ENSEMBL:ENSG00000167995	bestrophin 1
+ORPHANET:325524	Classic congenital lipoid adrenal hyperplasia due to STAR deficency	ENSEMBL:ENSG00000147465	steroidogenic acute regulatory protein
+ORPHANET:325448	Leydig cell hypoplasia due to LHB deficiency	ENSEMBL:ENSG00000104826	luteinizing hormone subunit beta
+ORPHANET:325529	Non-classic congenital lipoid adrenal hyperplasia due to STAR deficency	ENSEMBL:ENSG00000147465	steroidogenic acute regulatory protein
+ORPHANET:324977	Proteasome-associated autoinflammatory syndrome	ENSEMBL:ENSG00000204264	proteasome 20S subunit beta 8
+ORPHANET:324718	ABetaA21G amyloidosis	ENSEMBL:ENSG00000142192	amyloid beta precursor protein
+ORPHANET:324713	ABeta amyloidosis, Italian type	ENSEMBL:ENSG00000142192	amyloid beta precursor protein
+ORPHANET:324737	SRD5A3-CDG	ENSEMBL:ENSG00000128039	steroid 5 alpha-reductase 3
+ORPHANET:324723	ABeta amyloidosis, Arctic type	ENSEMBL:ENSG00000142192	amyloid beta precursor protein
+ORPHANET:324708	ABeta amyloidosis, Iowa type	ENSEMBL:ENSG00000142192	amyloid beta precursor protein
+ORPHANET:324703	ABetaL34V amyloidosis	ENSEMBL:ENSG00000142192	amyloid beta precursor protein
+ORPHANET:324611	Autosomal dominant Charcot-Marie-Tooth disease type 2 due to KIF5A mutation	ENSEMBL:ENSG00000155980	kinesin family member 5A
+ORPHANET:324588	Familial dyskinesia and facial myokymia	ENSEMBL:ENSG00000173175	adenylate cyclase 5
+ORPHANET:324601	X-linked cleft palate and ankyloglossia	ENSEMBL:ENSG00000122145	T-box transcription factor 22
+ORPHANET:324581	Benign Samaritan congenital myopathy	ENSEMBL:ENSG00000196218	ryanodine receptor 1
+ORPHANET:324585	Autosomal dominant intermediate Charcot-Marie-Tooth disease with neuropathic pain	ENSEMBL:ENSG00000158887	myelin protein zero
+ORPHANET:324569	Pontocerebellar hypoplasia type 8	ENSEMBL:ENSG00000131165	charged multivesicular body protein 1A
+ORPHANET:324575	Hyperinsulinism due to HNF1A deficiency	ENSEMBL:ENSG00000135100	HNF1 homeobox A
+ORPHANET:324561	Hypopigmentation-punctate palmoplantar keratoderma syndrome	ENSEMBL:ENSG00000197594	ectonucleotide pyrophosphatase/phosphodiesterase 1
+ORPHANET:324530	Autoinflammation-PLCG2-associated antibody deficiency-immune dysregulation	ENSEMBL:ENSG00000197943	phospholipase C gamma 2
+ORPHANET:324535	Combined oxidative phosphorylation defect type 11	ENSEMBL:ENSG00000155906	required for meiotic nuclear division 1 homolog
+ORPHANET:324525	Hypertrophic cardiomyopathy with kidney anomalies due to mitochondrial DNA mutation	ENSEMBL:ENSG00000209082	mitochondrially encoded tRNA-Leu (UUA/G) 1
+ORPHANET:324442	Autosomal recessive axonal neuropathy with neuromyotonia	ENSEMBL:ENSG00000169567	histidine triad nucleotide binding protein 1
+ORPHANET:324422	ALG13-CDG	ENSEMBL:ENSG00000101901	ALG13 UDP-N-acetylglucosaminyltransferase subunit
+ORPHANET:324410	X-linked intellectual disability-cardiomegaly-congestive heart failure syndrome	ENSEMBL:ENSG00000155962	chloride intracellular channel 2
+ORPHANET:324321	Sinoatrial node dysfunction and deafness	ENSEMBL:ENSG00000157388	calcium voltage-gated channel subunit alpha1 D
+ORPHANET:324299	Multiple paragangliomas associated with polycythemia	ENSEMBL:ENSG00000116016	endothelial PAS domain protein 1
+ORPHANET:324294	T-cell immunodeficiency with epidermodysplasia verruciformis	ENSEMBL:ENSG00000168421	ras homolog family member H
+ORPHANET:324290	Early-onset Lafora body disease	ENSEMBL:ENSG00000152784	PR/SET domain 8
+ORPHANET:324262	Autosomal recessive congenital cerebellar ataxia due to MGLUR1 deficiency	ENSEMBL:ENSG00000152822	glutamate metabotropic receptor 1
+ORPHANET:319691	NON RARE IN EUROPE: Partial color blindness, protan type	ENSEMBL:ENSG00000102076	opsin 1, long wave sensitive
+ORPHANET:319698	NON RARE IN EUROPE: Partial color blindness, deutan type	ENSEMBL:ENSG00000268221	opsin 1, medium wave sensitive
+ORPHANET:319705	NON RARE IN EUROPE: Parkinson disease	ENSEMBL:ENSG00000177628	glucosylceramidase beta 1
+ORPHANET:320360	MT-ATP6-related mitochondrial spastic paraplegia	ENSEMBL:ENSG00000198899	mitochondrially encoded ATP synthase membrane subunit 6
+ORPHANET:320370	Autosomal recessive spastic paraplegia type 43	ENSEMBL:ENSG00000131943	chromosome 19 open reading frame 12
+ORPHANET:320380	Autosomal recessive spastic paraplegia type 54	ENSEMBL:ENSG00000085788	DDHD domain containing 2
+ORPHANET:320375	Autosomal recessive spastic paraplegia type 55	ENSEMBL:ENSG00000130921	mitochondrial translation release factor in rescue
+ORPHANET:320391	Autosomal recessive spastic paraplegia type 46	ENSEMBL:ENSG00000070610	glucosylceramidase beta 2
+ORPHANET:320385	Hereditary sensory and autonomic neuropathy due to TECPR2 mutation	ENSEMBL:ENSG00000196663	tectonin beta-propeller repeat containing 2
+ORPHANET:320401	Autosomal recessive spastic paraplegia type 44	ENSEMBL:ENSG00000198835	gap junction protein gamma 2
+ORPHANET:320396	Autosomal recessive spastic paraplegia type 45	ENSEMBL:ENSG00000076685	5'-nucleotidase, cytosolic II
+ORPHANET:320411	Autosomal recessive spastic paraplegia type 56	ENSEMBL:ENSG00000155016	cytochrome P450 family 2 subfamily U member 1
+ORPHANET:319547	Mendelian susceptibility to mycobacterial diseases due to complete IFNgammaR2 deficiency	ENSEMBL:ENSG00000159128	interferon gamma receptor 2
+ORPHANET:319519	Combined oxidative phosphorylation defect type 14	ENSEMBL:ENSG00000145982	phenylalanyl-tRNA synthetase 2, mitochondrial
+ORPHANET:319524	Combined oxidative phosphorylation defect type 15	ENSEMBL:ENSG00000103707	mitochondrial methionyl-tRNA formyltransferase
+ORPHANET:319509	Combined oxidative phosphorylation defect type 9	ENSEMBL:ENSG00000114686	mitochondrial ribosomal protein L3
+ORPHANET:319514	Combined oxidative phosphorylation defect type 13	ENSEMBL:ENSG00000138035	polyribonucleotide nucleotidyltransferase 1
+ORPHANET:319589	Autosomal dominant mendelian susceptibility to mycobacterial diseases due to partial IFNgammaR2 deficiency	ENSEMBL:ENSG00000159128	interferon gamma receptor 2
+ORPHANET:319595	Mendelian susceptibility to mycobacterial diseases due to partial STAT1 deficiency	ENSEMBL:ENSG00000115415	signal transducer and activator of transcription 1
+ORPHANET:319574	Autosomal recessive mendelian susceptibility to mycobacterial diseases due to partial IFNgammaR2 deficiency	ENSEMBL:ENSG00000159128	interferon gamma receptor 2
+ORPHANET:319581	Autosomal dominant mendelian susceptibility to mycobacterial diseases due to partial IFNgammaR1 deficiency	ENSEMBL:ENSG00000027697	interferon gamma receptor 1
+ORPHANET:319563	Mendelian susceptibility to mycobacterial diseases due to complete ISG15 deficiency	ENSEMBL:ENSG00000187608	ISG15 ubiquitin like modifier
+ORPHANET:319569	Autosomal recessive mendelian susceptibility to mycobacterial diseases due to partial IFNgammaR1 deficiency	ENSEMBL:ENSG00000027697	interferon gamma receptor 1
+ORPHANET:319552	Mendelian susceptibility to mycobacterial diseases due to complete IL12RB1 deficiency	ENSEMBL:ENSG00000096996	interleukin 12 receptor subunit beta 1
+ORPHANET:319558	Mendelian susceptibility to mycobacterial diseases due to complete IL12B deficiency	ENSEMBL:ENSG00000113302	interleukin 12B
+ORPHANET:319651	Constitutional megaloblastic anemia with severe neurologic disease	ENSEMBL:ENSG00000228716	dihydrofolate reductase
+ORPHANET:319646	PGM1-CDG	ENSEMBL:ENSG00000079739	phosphoglucomutase 1
+ORPHANET:319640	Retinal macular dystrophy type 2	ENSEMBL:ENSG00000007062	prominin 1
+ORPHANET:319635	Amyloidosis cutis dyschromia	ENSEMBL:ENSG00000136235	glycoprotein nmb
+ORPHANET:319623	X-linked mendelian susceptibility to mycobacterial diseases due to CYBB deficiency	ENSEMBL:ENSG00000165168	cytochrome b-245 beta chain
+ORPHANET:319612	X-linked mendelian susceptibility to mycobacterial diseases due to IKBKG deficiency	ENSEMBL:ENSG00000269335	inhibitor of nuclear factor kappa B kinase regulatory subunit gamma
+ORPHANET:319600	Mendelian susceptibility to mycobacterial diseases due to partial IRF8 deficiency	ENSEMBL:ENSG00000140968	interferon regulatory factor 8
+ORPHANET:319678	Encephalopathy-hypertrophic cardiomyopathy-renal tubular disease syndrome	ENSEMBL:ENSG00000088682	coenzyme Q9
+ORPHANET:319675	Microcephalic primordial dwarfism, Dauber type	ENSEMBL:ENSG00000100503	ninein
+ORPHANET:319671	Alazami syndrome	ENSEMBL:ENSG00000174720	La ribonucleoprotein 7, transcriptional regulator
+ORPHANET:319303	Chromophobe renal cell carcinoma	ENSEMBL:ENSG00000135100	HNF1 homeobox A
+ORPHANET:319332	Autosomal recessive myogenic arthrogryposis multiplex congenita	ENSEMBL:ENSG00000131018	spectrin repeat containing nuclear envelope protein 1
+ORPHANET:319340	Carney complex-trismus-pseudocamptodactyly syndrome	ENSEMBL:ENSG00000133020	myosin heavy chain 8
+ORPHANET:319480	Acute myeloid leukemia with CEBPA somatic mutations	ENSEMBL:ENSG00000245848	CCAAT enhancer binding protein alpha
+ORPHANET:319504	Combined oxidative phosphorylation defect type 8	ENSEMBL:ENSG00000124608	alanyl-tRNA synthetase 2, mitochondrial
+ORPHANET:319462	Inherited cancer-predisposing syndrome due to biallelic BRCA2 mutations	ENSEMBL:ENSG00000139618	BRCA2 DNA repair associated
+ORPHANET:319199	Autosomal recessive spastic paraplegia type 53	ENSEMBL:ENSG00000155975	VPS37A subunit of ESCRT-I
+ORPHANET:319160	Congenital myopathy with internal nuclei and atypical cores	ENSEMBL:ENSG00000162004	coiled-coil domain containing 78
+ORPHANET:319189	Familial cortical myoclonus	ENSEMBL:ENSG00000140939	nucleolar protein 3
+ORPHANET:319192	Diencephalic-mesencephalic junction dysplasia	ENSEMBL:ENSG00000113555	protocadherin 12
+ORPHANET:319182	Wiedemann-Steiner syndrome	ENSEMBL:ENSG00000118058	lysine methyltransferase 2A
+ORPHANET:317428	Combined immunodeficiency due to ORAI1 deficiency	ENSEMBL:ENSG00000276045	ORAI calcium release-activated calcium modulator 1
+ORPHANET:317425	Severe combined immunodeficiency due to DNA-PKcs deficiency	ENSEMBL:ENSG00000253729	protein kinase, DNA-activated, catalytic subunit
+ORPHANET:317430	Combined immunodeficiency due to STIM1 deficiency	ENSEMBL:ENSG00000167323	stromal interaction molecule 1
+ORPHANET:317473	Pancytopenia due to IKZF1 mutations	ENSEMBL:ENSG00000185811	IKAROS family zinc finger 1
+ORPHANET:317476	X-linked immunodeficiency with magnesium defect, Epstein-Barr virus infection and neoplasia	ENSEMBL:ENSG00000102158	magnesium transporter 1
+ORPHANET:315311	Classic congenital adrenal hyperplasia due to 21-hydroxylase deficiency, simple virilizing form	ENSEMBL:ENSG00000231852	cytochrome P450 family 21 subfamily A member 2
+ORPHANET:315306	Classic congenital adrenal hyperplasia due to 21-hydroxylase deficiency, salt wasting form	ENSEMBL:ENSG00000231852	cytochrome P450 family 21 subfamily A member 2
+ORPHANET:314978	X-linked non progressive cerebellar ataxia	ENSEMBL:ENSG00000067842	ATPase plasma membrane Ca2+ transporting 3
+ORPHANET:314918	Mild Canavan disease	ENSEMBL:ENSG00000108381	aspartoacylase
+ORPHANET:314911	Severe Canavan disease	ENSEMBL:ENSG00000108381	aspartoacylase
+ORPHANET:314667	TMEM165-CDG	ENSEMBL:ENSG00000134851	transmembrane protein 165
+ORPHANET:314689	Combined immunodeficiency due to STK4 deficiency	ENSEMBL:ENSG00000101109	serine/threonine kinase 4
+ORPHANET:314652	Variant ABeta2M amyloidosis	ENSEMBL:ENSG00000166710	beta-2-microglobulin
+ORPHANET:314662	Segmental progressive overgrowth syndrome with fibroadipose hyperplasia	ENSEMBL:ENSG00000121879	phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunit alpha
+ORPHANET:314655	Severe neonatal hypotonia-seizures-encephalopathy syndrome due to 5q31.3 microdeletion	ENSEMBL:ENSG00000185129	purine rich element binding protein A
+ORPHANET:314629	CLN11 disease	ENSEMBL:ENSG00000030582	granulin precursor
+ORPHANET:314637	Mitochondrial hypertrophic cardiomyopathy with lactic acidosis due to MTO1 deficiency	ENSEMBL:ENSG00000135297	mitochondrial tRNA translation optimization 1
+ORPHANET:314632	ATP13A2-related juvenile neuronal ceroid lipofuscinosis	ENSEMBL:ENSG00000159363	ATPase cation transporting 13A2
+ORPHANET:314802	Short stature due to partial GHR deficiency	ENSEMBL:ENSG00000112964	growth hormone receptor
+ORPHANET:314811	Short stature due to GHSR deficiency	ENSEMBL:ENSG00000121853	growth hormone secretagogue receptor
+ORPHANET:314795	SHOX-related short stature	ENSEMBL:ENSG00000185960	short stature homeobox
+ORPHANET:314718	Lethal arteriopathy syndrome due to fibulin-4 deficiency	ENSEMBL:ENSG00000172638	EGF containing fibulin extracellular matrix protein 2
+ORPHANET:314721	Atypical dentin dysplasia due to SMOC2 deficiency	ENSEMBL:ENSG00000112562	SPARC related modular calcium binding 2
+ORPHANET:370109	Ataxia-telangiectasia variant	ENSEMBL:ENSG00000149311	ATM serine/threonine kinase
+ORPHANET:370097	Oculocutaneous albinism type 6	ENSEMBL:ENSG00000188467	solute carrier family 24 member 5
+ORPHANET:370396	Small cell carcinoma of the ovary	ENSEMBL:ENSG00000127616	SWI/SNF related, matrix associated, actin dependent regulator of chromatin, subfamily a, member 4
+ORPHANET:370348	Peripheral primitive neuroectodermal tumor	ENSEMBL:ENSG00000151702	Fli-1 proto-oncogene, ETS transcription factor
+ORPHANET:370022	Ataxia-intellectual disability-oculomotor apraxia-cerebellar cysts syndrome	ENSEMBL:ENSG00000101680	laminin subunit alpha 1
+ORPHANET:370088	Acute infantile liver failure-multisystemic involvement syndrome	ENSEMBL:ENSG00000133706	leucyl-tRNA synthetase 1
+ORPHANET:370997	Muscle-eye-brain disease with bilateral multicystic leucodystrophy	ENSEMBL:ENSG00000173402	dystroglycan 1
+ORPHANET:370921	STT3A-CDG	ENSEMBL:ENSG00000134910	STT3 oligosaccharyltransferase complex catalytic subunit A
+ORPHANET:370924	STT3B-CDG	ENSEMBL:ENSG00000163527	STT3 oligosaccharyltransferase complex catalytic subunit B
+ORPHANET:370927	SSR4-CDG	ENSEMBL:ENSG00000180879	signal sequence receptor subunit 4
+ORPHANET:370930	XYLT1-CDG	ENSEMBL:ENSG00000103489	xylosyltransferase 1
+ORPHANET:370933	GM3 synthase deficiency	ENSEMBL:ENSG00000115525	ST3 beta-galactoside alpha-2,3-sialyltransferase 5
+ORPHANET:370943	Autism spectrum disorder-epilepsy-arthrogryposis syndrome	ENSEMBL:ENSG00000117620	solute carrier family 35 member A3
+ORPHANET:369929	Primary hyperaldosteronism-seizures-neurological abnormalities syndrome	ENSEMBL:ENSG00000157388	calcium voltage-gated channel subunit alpha1 D
+ORPHANET:369920	Pontocerebellar hypoplasia type 9	ENSEMBL:ENSG00000116337	adenosine monophosphate deaminase 2
+ORPHANET:369939	Severe motor and intellectual disabilities-sensorineural deafness-dystonia syndrome	ENSEMBL:ENSG00000185825	B cell receptor associated protein 31
+ORPHANET:369955	Methylmalonic acidemia with homocystinuria, type cblJ	ENSEMBL:ENSG00000119688	ATP binding cassette subfamily D member 4
+ORPHANET:369970	Microcornea-myopic chorioretinal atrophy-telecanthus syndrome	ENSEMBL:ENSG00000140873	ADAM metallopeptidase with thrombospondin type 1 motif 18
+ORPHANET:369962	Methylmalonic acidemia with homocystinuria, type cblX	ENSEMBL:ENSG00000172534	host cell factor C1
+ORPHANET:370002	Focal palmoplantar keratoderma with joint keratoses	ENSEMBL:ENSG00000134760	desmoglein 1
+ORPHANET:369999	Diffuse palmoplantar keratoderma with painful fissures	ENSEMBL:ENSG00000134760	desmoglein 1
+ORPHANET:369837	Intellectual disability-seizures-hypophosphatasia-ophthalmic-skeletal anomalies syndrome	ENSEMBL:ENSG00000124155	phosphatidylinositol glycan anchor biosynthesis class T
+ORPHANET:369840	TRAPPC11-related limb-girdle muscular dystrophy R18	ENSEMBL:ENSG00000168538	trafficking protein particle complex subunit 11
+ORPHANET:369847	Intellectual disability-hyperkinetic movement-truncal ataxia syndrome	ENSEMBL:ENSG00000168538	trafficking protein particle complex subunit 11
+ORPHANET:369861	Congenital sideroblastic anemia-B-cell immunodeficiency-periodic fever-developmental delay syndrome	ENSEMBL:ENSG00000072756	tRNA nucleotidyl transferase 1
+ORPHANET:369867	Autosomal recessive intermediate Charcot-Marie-Tooth disease type C	ENSEMBL:ENSG00000171680	pleckstrin homology and RhoGEF domain containing G5
+ORPHANET:369873	Obesity due to SIM1 deficiency	ENSEMBL:ENSG00000112246	SIM bHLH transcription factor 1
+ORPHANET:369891	Developmental delay-facial dysmorphism syndrome due to MED13L deficiency	ENSEMBL:ENSG00000123066	mediator complex subunit 13L
+ORPHANET:369897	Mitochondrial DNA depletion syndrome, encephalomyopathic form with variable craniofacial anomalies	ENSEMBL:ENSG00000112234	F-box and leucine rich repeat protein 4
+ORPHANET:369913	Combined oxidative phosphorylation defect type 17	ENSEMBL:ENSG00000006744	elaC ribonuclease Z 2
+ORPHANET:364063	Infantile epileptic-dyskinetic encephalopathy	ENSEMBL:ENSG00000004848	aristaless related homeobox
+ORPHANET:364043	ALK-positive large B-cell lymphoma	ENSEMBL:ENSG00000171094	ALK receptor tyrosine kinase
+ORPHANET:364028	X-linked intellectual disability due to GRIA3 mutations	ENSEMBL:ENSG00000125675	glutamate ionotropic receptor AMPA type subunit 3
+ORPHANET:1194	TMEM70-related mitochondrial encephalo-cardio-myopathy	ENSEMBL:ENSG00000175606	transmembrane protein 70
+ORPHANET:363989	Familial benign flecked retina	ENSEMBL:ENSG00000127472	phospholipase A2 group V
+ORPHANET:363981	Charcot-Marie-Tooth disease type 4B3	ENSEMBL:ENSG00000100241	SET binding factor 1
+ORPHANET:363969	Autosomal recessive cerebral atrophy	ENSEMBL:ENSG00000137648	transmembrane serine protease 4
+ORPHANET:363972	Noonan syndrome-like disorder with juvenile myelomonocytic leukemia	ENSEMBL:ENSG00000110395	Cbl proto-oncogene
+ORPHANET:363965	Koolen-De Vries syndrome due to a point mutation	ENSEMBL:ENSG00000120071	KAT8 regulatory NSL complex subunit 1
+ORPHANET:363958	17q21.31 microdeletion syndrome	ENSEMBL:ENSG00000120071	KAT8 regulatory NSL complex subunit 1
+ORPHANET:363727	X-linked dyserythropoietic anemia with abnormal platelets and neutropenia	ENSEMBL:ENSG00000102145	GATA binding protein 1
+ORPHANET:363722	Alexander disease type II	ENSEMBL:ENSG00000131095	glial fibrillary acidic protein
+ORPHANET:363717	Alexander disease type I	ENSEMBL:ENSG00000131095	glial fibrillary acidic protein
+ORPHANET:363700	Neurofibromatosis type 1 due to NF1 mutation or intragenic deletion	ENSEMBL:ENSG00000196712	neurofibromin 1
+ORPHANET:363694	Hyperuricemia-pulmonary hypertension-renal failure-alkalosis syndrome	ENSEMBL:ENSG00000104835	seryl-tRNA synthetase 2, mitochondrial
+ORPHANET:363686	Severe intellectual disability-poor language-strabismus-grimacing face-long fingers syndrome	ENSEMBL:ENSG00000143614	GATA zinc finger domain containing 2B
+ORPHANET:363677	Childhood-onset autosomal recessive myopathy with external ophthalmoplegia	ENSEMBL:ENSG00000125414	myosin heavy chain 2
+ORPHANET:363417	Temtamy preaxial brachydactyly syndrome	ENSEMBL:ENSG00000131873	chondroitin sulfate synthase 1
+ORPHANET:363409	Fetal akinesia-cerebral and retinal hemorrhage syndrome	ENSEMBL:ENSG00000079805	dynamin 2
+ORPHANET:363412	Hypomyelination with brain stem and spinal cord involvement and leg spasticity	ENSEMBL:ENSG00000115866	aspartyl-tRNA synthetase 1
+ORPHANET:363432	Autosomal recessive congenital cerebellar ataxia due to GRID2 deficiency	ENSEMBL:ENSG00000152208	glutamate ionotropic receptor delta type subunit 2
+ORPHANET:363424	Multiple mitochondrial dysfunctions syndrome type 3	ENSEMBL:ENSG00000181873	iron-sulfur cluster assembly factor IBA57
+ORPHANET:363396	High myopia-sensorineural deafness syndrome	ENSEMBL:ENSG00000184564	SLIT and NTRK like family member 6
+ORPHANET:363400	Severe neurodegenerative syndrome with lipodystrophy	ENSEMBL:ENSG00000168000	BSCL2 lipid droplet biogenesis associated, seipin
+ORPHANET:363618	LMNA-related cardiocutaneous progeria syndrome	ENSEMBL:ENSG00000160789	lamin A/C
+ORPHANET:363623	GMPPB-related limb-girdle muscular dystrophy R19	ENSEMBL:ENSG00000173540	GDP-mannose pyrophosphorylase B
+ORPHANET:363649	Mandibular hypoplasia-deafness-progeroid features-lipodystrophy syndrome	ENSEMBL:ENSG00000062822	DNA polymerase delta 1, catalytic subunit
+ORPHANET:363654	X-linked parkinsonism-spasticity syndrome	ENSEMBL:ENSG00000182220	ATPase H+ transporting accessory protein 2
+ORPHANET:363665	Acroosteolysis-keloid-like lesions-premature aging syndrome	ENSEMBL:ENSG00000113721	platelet derived growth factor receptor beta
+ORPHANET:363540	Leukoencephalopathy with mild cerebellar ataxia and white matter edema	ENSEMBL:ENSG00000114859	chloride voltage-gated channel 2
+ORPHANET:363549	Acute encephalopathy with biphasic seizures and late reduced diffusion	ENSEMBL:ENSG00000128271	adenosine A2a receptor
+ORPHANET:363611	CTCF-related neurodevelopmental disorder	ENSEMBL:ENSG00000102974	CCCTC-binding factor
+ORPHANET:363523	Hypohidrosis-enamel hypoplasia-palmoplantar keratoderma-intellectual disability syndrome	ENSEMBL:ENSG00000133103	component of oligomeric golgi complex 6
+ORPHANET:363534	Mitochondrial DNA depletion syndrome, hepatocerebrorenal form	ENSEMBL:ENSG00000107815	twinkle mtDNA helicase
+ORPHANET:363528	Intellectual disability-strabismus syndrome	ENSEMBL:ENSG00000213638	adenosine deaminase tRNA specific 3
+ORPHANET:363444	THOC6-related developmental delay-microcephaly-facial dysmorphism syndrome	ENSEMBL:ENSG00000131652	THO complex subunit 6
+ORPHANET:363454	BICD2-related autosomal dominant childhood-onset proximal spinal muscular atrophy	ENSEMBL:ENSG00000185963	BICD cargo adaptor 2
+ORPHANET:357329	Combined immunodeficiency due to IL21R deficiency	ENSEMBL:ENSG00000103522	interleukin 21 receptor
+ORPHANET:357237	Severe combined immunodeficiency due to CARD11 deficiency	ENSEMBL:ENSG00000198286	caspase recruitment domain family member 11
+ORPHANET:356978	D,L-2-hydroxyglutaric aciduria	ENSEMBL:ENSG00000100075	solute carrier family 25 member 1
+ORPHANET:356961	SLC35A2-CDG	ENSEMBL:ENSG00000102100	solute carrier family 35 member A2
+ORPHANET:357008	Hemolytic uremic syndrome with DGKE deficiency	ENSEMBL:ENSG00000153933	diacylglycerol kinase epsilon
+ORPHANET:356996	ANK3-related intellectual disability-sleep disturbance syndrome	ENSEMBL:ENSG00000151150	ankyrin 3
+ORPHANET:357043	Amyotrophic lateral sclerosis type 4	ENSEMBL:ENSG00000107290	senataxin
+ORPHANET:357064	Autosomal recessive cutis laxa type 2B	ENSEMBL:ENSG00000183010	pyrroline-5-carboxylate reductase 1
+ORPHANET:352654	Early-onset progressive neurodegeneration-blindness-ataxia-spasticity syndrome	ENSEMBL:ENSG00000154277	ubiquitin C-terminal hydrolase L1
+ORPHANET:352662	Corneal intraepithelial dyskeratosis-palmoplantar hyperkeratosis-laryngeal dyskeratosis syndrome	ENSEMBL:ENSG00000091592	NLR family pyrin domain containing 1
+ORPHANET:352641	Autosomal recessive cerebellar ataxia with late-onset spasticity	ENSEMBL:ENSG00000070610	glucosylceramidase beta 2
+ORPHANET:352649	Brain dopamine-serotonin vesicular transport disease	ENSEMBL:ENSG00000165646	solute carrier family 18 member A2
+ORPHANET:352596	Progressive myoclonic epilepsy with dystonia	ENSEMBL:ENSG00000162065	TBC1 domain family member 24
+ORPHANET:352577	Bainbridge-Ropers syndrome	ENSEMBL:ENSG00000141431	ASXL transcriptional regulator 3
+ORPHANET:352587	Focal epilepsy-intellectual disability-cerebro-cerebellar malformation	ENSEMBL:ENSG00000162065	TBC1 domain family member 24
+ORPHANET:352734	Minimal pigment oculocutaneous albinism type 1	ENSEMBL:ENSG00000077498	tyrosinase
+ORPHANET:352737	Temperature-sensitive oculocutaneous albinism type 1	ENSEMBL:ENSG00000077498	tyrosinase
+ORPHANET:352709	CLN13 disease	ENSEMBL:ENSG00000174080	cathepsin F
+ORPHANET:352712	Facial dysmorphism-immunodeficiency-livedo-short stature syndrome	ENSEMBL:ENSG00000177084	DNA polymerase epsilon, catalytic subunit
+ORPHANET:352718	Progressive retinal dystrophy due to retinol transport defect	ENSEMBL:ENSG00000138207	retinol binding protein 4
+ORPHANET:352723	Attenuated Chédiak-Higashi syndrome	ENSEMBL:ENSG00000143669	lysosomal trafficking regulator
+ORPHANET:352665	Neurodevelopmental disorder-craniofacial dysmorphism-cardiac defect-skeletal anomalies syndrome due to 9q21.3 microdeletion	ENSEMBL:ENSG00000165119	heterogeneous nuclear ribonucleoprotein K
+ORPHANET:352670	Autosomal dominant intermediate Charcot-Marie-Tooth disease type F	ENSEMBL:ENSG00000114450	G protein subunit beta 4
+ORPHANET:352675	X-linked Charcot-Marie-Tooth disease type 6	ENSEMBL:ENSG00000067992	pyruvate dehydrogenase kinase 3
+ORPHANET:352682	Cobblestone lissencephaly without muscular or ocular involvement	ENSEMBL:ENSG00000091136	laminin subunit beta 1
+ORPHANET:353277	Rubinstein-Taybi syndrome due to CREBBP mutations	ENSEMBL:ENSG00000005339	CREB binding protein
+ORPHANET:353217	Epileptic encephalopathy with global cerebral demyelination	ENSEMBL:ENSG00000115840	solute carrier family 25 member 12
+ORPHANET:352745	Oculocutaneous albinism type 7	ENSEMBL:ENSG00000148655	leucine rich melanocyte differentiation associated
+ORPHANET:353320	Pyruvate carboxylase deficiency, benign type	ENSEMBL:ENSG00000173599	pyruvate carboxylase
+ORPHANET:353308	Pyruvate carboxylase deficiency, infantile type	ENSEMBL:ENSG00000173599	pyruvate carboxylase
+ORPHANET:353314	Pyruvate carboxylase deficiency, severe neonatal type	ENSEMBL:ENSG00000173599	pyruvate carboxylase
+ORPHANET:353298	Roifman syndrome	ENSEMBL:ENSG00000264229	RNA, U4atac small nuclear (U12-dependent splicing)
+ORPHANET:353281	Rubinstein-Taybi syndrome due to 16p13.3 microdeletion	ENSEMBL:ENSG00000005339	CREB binding protein
+ORPHANET:353284	Rubinstein-Taybi syndrome due to EP300 haploinsufficiency	ENSEMBL:ENSG00000100393	E1A binding protein p300
+ORPHANET:352403	Spectrin-associated autosomal recessive cerebellar ataxia	ENSEMBL:ENSG00000173898	spectrin beta, non-erythrocytic 2
+ORPHANET:352333	Congenital ichthyosis-intellectual disability-spastic quadriplegia syndrome	ENSEMBL:ENSG00000118402	ELOVL fatty acid elongase 4
+ORPHANET:352328	MEGDEL syndrome	ENSEMBL:ENSG00000122335	serine active site containing 1
+ORPHANET:352447	Progressive external ophthalmoplegia-myopathy-emaciation syndrome	ENSEMBL:ENSG00000125871	mitochondrial genome maintenance exonuclease 1
+ORPHANET:352530	Intellectual disability-obesity-brain malformations-facial dysmorphism syndrome	ENSEMBL:ENSG00000167632	trafficking protein particle complex subunit 9
+ORPHANET:352563	Infantile hypertrophic cardiomyopathy due to MRPL44 deficiency	ENSEMBL:ENSG00000135900	mitochondrial ribosomal protein L44
+ORPHANET:352479	ISPD-related limb-girdle muscular dystrophy R20	ENSEMBL:ENSG00000214960	CDP-L-ribitol pyrophosphorylase A
+ORPHANET:352470	DNA2-related mitochondrial DNA deletion syndrome	ENSEMBL:ENSG00000138346	DNA replication helicase/nuclease 2
+ORPHANET:352490	Autism spectrum disorder due to AUTS2 deficiency	ENSEMBL:ENSG00000158321	activator of transcription and developmental regulator AUTS2
+ORPHANET:294016	Microcephaly-capillary malformation syndrome	ENSEMBL:ENSG00000124356	STAM binding protein
+ORPHANET:293964	Hypoinsulinemic hypoglycemia and body hemihypertrophy	ENSEMBL:ENSG00000105221	AKT serine/threonine kinase 2
+ORPHANET:293978	Deficiency in anterior pituitary function-variable immunodeficiency syndrome	ENSEMBL:ENSG00000077150	nuclear factor kappa B subunit 2
+ORPHANET:293955	Childhood encephalopathy due to thiamine pyrophosphokinase deficiency	ENSEMBL:ENSG00000196511	thiamin pyrophosphokinase 1
+ORPHANET:293948	1p21.3 microdeletion syndrome	ENSEMBL:ENSG00000188641	dihydropyrimidine dehydrogenase
+ORPHANET:293936	EDICT syndrome	ENSEMBL:ENSG00000207695	microRNA 184
+ORPHANET:293925	Lethal occipital encephalocele-skeletal dysplasia syndrome	ENSEMBL:ENSG00000003137	cytochrome P450 family 26 subfamily B member 1
+ORPHANET:293864	Hypoplastic pancreas-intestinal atresia-hypoplastic gallbladder syndrome	ENSEMBL:ENSG00000185002	regulatory factor X6
+ORPHANET:293822	MITF-related melanoma and renal cell carcinoma predisposition syndrome	ENSEMBL:ENSG00000187098	melanocyte inducing transcription factor
+ORPHANET:293825	Congenital dyserythropoietic anemia type IV	ENSEMBL:ENSG00000105610	KLF transcription factor 1
+ORPHANET:293707	Blepharophimosis-intellectual disability syndrome, MKB type	ENSEMBL:ENSG00000184634	mediator complex subunit 12
+ORPHANET:293633	PYCR1-related De Barsy syndrome	ENSEMBL:ENSG00000183010	pyrroline-5-carboxylate reductase 1
+ORPHANET:289891	Hypermethioninemia due to glycine N-methyltransferase deficiency	ENSEMBL:ENSG00000124713	glycine N-methyltransferase
+ORPHANET:289916	Vitamin B12-unresponsive methylmalonic acidemia type mut0	ENSEMBL:ENSG00000146085	methylmalonyl-CoA mutase
+ORPHANET:289846	Glutathione synthetase deficiency with 5-oxoprolinuria	ENSEMBL:ENSG00000100983	glutathione synthetase
+ORPHANET:289849	Glutathione synthetase deficiency without 5-oxoprolinuria	ENSEMBL:ENSG00000100983	glutathione synthetase
+ORPHANET:289560	Mitochondrial membrane protein-associated neurodegeneration	ENSEMBL:ENSG00000131943	chromosome 19 open reading frame 12
+ORPHANET:289548	Inherited isolated adrenal insufficiency due to partial CYP11A1 deficiency	ENSEMBL:ENSG00000140459	cytochrome P450 family 11 subfamily A member 1
+ORPHANET:289539	BAP1-related tumor predisposition syndrome	ENSEMBL:ENSG00000163930	BRCA1 associated protein 1
+ORPHANET:289601	Hereditary arterial and articular multiple calcification syndrome	ENSEMBL:ENSG00000135318	5'-nucleotidase ecto
+ORPHANET:293381	Epithelial recurrent erosion dystrophy	ENSEMBL:ENSG00000065618	collagen type XVII alpha 1 chain
+ORPHANET:293603	Congenital hereditary endothelial dystrophy type II	ENSEMBL:ENSG00000088836	solute carrier family 4 member 11
+ORPHANET:293150	Familial clubfoot due to PITX1 point mutation	ENSEMBL:ENSG00000069011	paired like homeodomain 1
+ORPHANET:741	Familial mitral valve prolapse	ENSEMBL:ENSG00000166341	dachsous cadherin-related 1
+ORPHANET:293144	Familial clubfoot due to 5q31 microdeletion	ENSEMBL:ENSG00000069011	paired like homeodomain 1
+ORPHANET:293168	Infantile-onset ascending hereditary spastic paralysis	ENSEMBL:ENSG00000003393	alsin Rho guanine nucleotide exchange factor ALS2
+ORPHANET:293165	Skin fragility-woolly hair-palmoplantar keratoderma syndrome	ENSEMBL:ENSG00000096696	desmoplakin
+ORPHANET:293284	Tetrahydrobiopterin-responsive hyperphenylalaninemia/phenylketonuria	ENSEMBL:ENSG00000171759	phenylalanine hydroxylase
+ORPHANET:2394	Pyruvate dehydrogenase E3 deficiency	ENSEMBL:ENSG00000091140	dihydrolipoamide dehydrogenase
+ORPHANET:2686	Cyclic neutropenia	ENSEMBL:ENSG00000197561	elastase, neutrophil expressed
+ORPHANET:284414	Glycerol kinase deficiency, adult form	ENSEMBL:ENSG00000198814	glycerol kinase
+ORPHANET:284417	Phosphoserine aminotransferase deficiency, infantile/juvenile form	ENSEMBL:ENSG00000135069	phosphoserine aminotransferase 1
+ORPHANET:284426	Glycogen storage disease due to lactate dehydrogenase M-subunit deficiency	ENSEMBL:ENSG00000134333	lactate dehydrogenase A
+ORPHANET:284435	Glycogen storage disease due to lactate dehydrogenase H-subunit deficiency	ENSEMBL:ENSG00000111716	lactate dehydrogenase B
+ORPHANET:284973	Marfan syndrome type 2	ENSEMBL:ENSG00000163513	transforming growth factor beta receptor 2
+ORPHANET:284963	Marfan syndrome type 1	ENSEMBL:ENSG00000166147	fibrillin 1
+ORPHANET:284984	Aneurysm-osteoarthritis syndrome	ENSEMBL:ENSG00000166949	SMAD family member 3
+ORPHANET:284979	Neonatal Marfan syndrome	ENSEMBL:ENSG00000166147	fibrillin 1
+ORPHANET:289377	Early-onset myopathy with fatal cardiomyopathy	ENSEMBL:ENSG00000155657	titin
+ORPHANET:289380	Myosclerosis	ENSEMBL:ENSG00000142173	collagen type VI alpha 2 chain
+ORPHANET:289290	Hypermethioninemia encephalopathy due to adenosine kinase deficiency	ENSEMBL:ENSG00000156110	adenosine kinase
+ORPHANET:289266	Early-onset epileptic encephalopathy and intellectual disability due to GRIN2A mutation	ENSEMBL:ENSG00000183454	glutamate ionotropic receptor NMDA type subunit 2A
+ORPHANET:289307	Developmental delay due to methylmalonate semialdehyde dehydrogenase deficiency	ENSEMBL:ENSG00000119711	aldehyde dehydrogenase 6 family member A1
+ORPHANET:289504	Combined malonic and methylmalonic acidemia	ENSEMBL:ENSG00000176715	acyl-CoA synthetase family member 3
+ORPHANET:289513	12q15q21.1 microdeletion syndrome	ENSEMBL:ENSG00000111596	CCR4-NOT transcription complex subunit 2
+ORPHANET:289465	Isolated congenital adermatoglyphia	ENSEMBL:ENSG00000163104	SWI/SNF-related, matrix-associated actin-dependent regulator of chromatin, subfamily a, containing DEAD/H box 1
+ORPHANET:281090	Syndromic recessive X-linked ichthyosis	ENSEMBL:ENSG00000101846	steroid sulfatase
+ORPHANET:281201	Keratosis linearis-ichthyosis congenita-sclerosing keratoderma syndrome	ENSEMBL:ENSG00000132963	proteasome maturation protein
+ORPHANET:281127	Acral self-healing collodion baby	ENSEMBL:ENSG00000092295	transglutaminase 1
+ORPHANET:280628	Familial progressive hyper- and hypopigmentation	ENSEMBL:ENSG00000049130	KIT ligand
+ORPHANET:280633	Multiple congenital anomalies-hypotonia-seizures syndrome	ENSEMBL:ENSG00000197563	phosphatidylinositol glycan anchor biosynthesis class N
+ORPHANET:280615	Hemoglobinopathy Toms River	ENSEMBL:ENSG00000196565	hemoglobin subunit gamma 2
+ORPHANET:280598	Hereditary sensorimotor neuropathy with hyperelastic skin	ENSEMBL:ENSG00000140092	fibulin 5
+ORPHANET:280620	Progressive myoclonic epilepsy type 6	ENSEMBL:ENSG00000108433	golgi SNAP receptor complex member 2
+ORPHANET:280671	Megaconial congenital muscular dystrophy	ENSEMBL:ENSG00000100288	choline kinase beta
+ORPHANET:280640	Occipital pachygyria and polymicrogyria	ENSEMBL:ENSG00000050555	laminin subunit gamma 3
+ORPHANET:280654	Autosomal recessive nail dysplasia	ENSEMBL:ENSG00000164930	frizzled class receptor 6
+ORPHANET:280785	Bullous diffuse cutaneous mastocytosis	ENSEMBL:ENSG00000157404	KIT proto-oncogene, receptor tyrosine kinase
+ORPHANET:280794	Pseudoxanthomatous diffuse cutaneous mastocytosis	ENSEMBL:ENSG00000157404	KIT proto-oncogene, receptor tyrosine kinase
+ORPHANET:280679	Moyamoya angiopathy-short stature-facial dysmorphism-hypergonadotropic hypogonadism syndrome	ENSEMBL:ENSG00000185515	BRCA1/BRCA2-containing complex subunit 3
+ORPHANET:284149	Craniosynostosis-dental anomalies	ENSEMBL:ENSG00000137070	interleukin 11 receptor subunit alpha
+ORPHANET:284139	Larsen-like syndrome, B3GAT3 type	ENSEMBL:ENSG00000149541	beta-1,3-glucuronyltransferase 3
+ORPHANET:284169	Facial dysmorphism-developmental delay-behavioral abnormalities syndrome due to 10p11.21p12.31 microdeletion	ENSEMBL:ENSG00000095787	WW domain containing adaptor with coiled-coil
+ORPHANET:284247	Familial retinal arterial macroaneurysm	ENSEMBL:ENSG00000163453	insulin like growth factor binding protein 7
+ORPHANET:284232	Autosomal dominant Charcot-Marie-Tooth disease type 2O	ENSEMBL:ENSG00000197102	dynein cytoplasmic 1 heavy chain 1
+ORPHANET:284271	Autosomal recessive cerebellar ataxia-psychomotor delay syndrome	ENSEMBL:ENSG00000143469	synaptotagmin 14
+ORPHANET:284324	Childhood-onset autosomal recessive slowly progressive spinocerebellar ataxia	ENSEMBL:ENSG00000166340	tripeptidyl peptidase 1
+ORPHANET:284282	Autosomal recessive cerebellar ataxia-epilepsy-intellectual disability syndrome due to WWOX deficiency	ENSEMBL:ENSG00000186153	WW domain containing oxidoreductase
+ORPHANET:284289	Adult-onset autosomal recessive cerebellar ataxia	ENSEMBL:ENSG00000160746	anoctamin 10
+ORPHANET:284343	DICER1 tumor-predisposition syndrome	ENSEMBL:ENSG00000100697	dicer 1, ribonuclease III
+ORPHANET:284411	Glycerol kinase deficiency, juvenile form	ENSEMBL:ENSG00000198814	glycerol kinase
+ORPHANET:282166	Inherited Creutzfeldt-Jakob disease	ENSEMBL:ENSG00000171867	prion protein
+ORPHANET:284130	NON RARE IN EUROPE: Rheumatoid arthritis	ENSEMBL:ENSG00000196126	major histocompatibility complex, class II, DR beta 1
+ORPHANET:309854	Cirrhosis-dystonia-polycythemia-hypermanganesemia syndrome	ENSEMBL:ENSG00000196660	solute carrier family 30 member 10
+ORPHANET:309803	Rhizomelic chondrodysplasia punctata type 3	ENSEMBL:ENSG00000018510	alkylglycerone phosphate synthase
+ORPHANET:309789	Rhizomelic chondrodysplasia punctata type 1	ENSEMBL:ENSG00000112357	peroxisomal biogenesis factor 7
+ORPHANET:309796	Rhizomelic chondrodysplasia punctata type 2	ENSEMBL:ENSG00000116906	glyceronephosphate O-acyltransferase
+ORPHANET:314022	Gastric adenocarcinoma and proximal polyposis of the stomach	ENSEMBL:ENSG00000134982	APC regulator of WNT signaling pathway
+ORPHANET:313892	Developmental and speech delay due to SOX5 deficiency	ENSEMBL:ENSG00000134532	SRY-box transcription factor 5
+ORPHANET:313884	12p12.1 microdeletion syndrome	ENSEMBL:ENSG00000134532	SRY-box transcription factor 5
+ORPHANET:313855	FGFR2-related bent bone dysplasia	ENSEMBL:ENSG00000066468	fibroblast growth factor receptor 2
+ORPHANET:313850	Infantile cerebellar-retinal degeneration	ENSEMBL:ENSG00000100412	aconitase 2
+ORPHANET:313846	Familial cutaneous telangiectasia and oropharyngeal cancer predisposition syndrome	ENSEMBL:ENSG00000175054	ATR serine/threonine kinase
+ORPHANET:313800	Retinal dystrophy-optic nerve edema-splenomegaly-anhidrosis-migraine headache syndrome	ENSEMBL:ENSG00000073331	alpha kinase 1
+ORPHANET:313795	Jawad syndrome	ENSEMBL:ENSG00000101773	RB binding protein 8, endonuclease
+ORPHANET:313772	Early-onset spastic ataxia-myoclonic epilepsy-neuropathy syndrome	ENSEMBL:ENSG00000141385	AFG3 like matrix AAA peptidase subunit 2
+ORPHANET:314603	Autosomal recessive spastic ataxia with leukoencephalopathy	ENSEMBL:ENSG00000247626	methionyl-tRNA synthetase 2, mitochondrial
+ORPHANET:314597	Chudley-McCullough syndrome	ENSEMBL:ENSG00000121957	G protein signaling modulator 2
+ORPHANET:314555	Facial dysmorphism-ocular anomalies-osteopenia-intellectual disability-dental anomalies syndrome	ENSEMBL:ENSG00000176842	iroquois homeobox 5
+ORPHANET:314394	Short stature-onychodysplasia-facial dysmorphism-hypotrichosis syndrome	ENSEMBL:ENSG00000164087	POC1 centriolar protein A
+ORPHANET:314399	Autosomal dominant aplasia and myelodysplasia	ENSEMBL:ENSG00000174780	signal recognition particle 72
+ORPHANET:314404	Autosomal dominant cerebellar ataxia-deafness-narcolepsy syndrome	ENSEMBL:ENSG00000130816	DNA methyltransferase 1
+ORPHANET:314373	Chronic infantile diarrhea due to guanylate cyclase 2C overactivity	ENSEMBL:ENSG00000070019	guanylate cyclase 2C
+ORPHANET:314376	Intestinal obstruction in the newborn due to guanylate cyclase 2C deficiency	ENSEMBL:ENSG00000070019	guanylate cyclase 2C
+ORPHANET:314381	Hereditary sensory and autonomic neuropathy type 6	ENSEMBL:ENSG00000151914	dystonin
+ORPHANET:314051	Leukoencephalopathy-thalamus and brainstem anomalies-high lactate syndrome	ENSEMBL:ENSG00000103356	glutamyl-tRNA synthetase 2, mitochondrial
+ORPHANET:306674	Kufor-Rakeb syndrome	ENSEMBL:ENSG00000159363	ATPase cation transporting 13A2
+ORPHANET:308380	Methylcobalamin deficiency type cblDv1	ENSEMBL:ENSG00000168288	metabolism of cobalamin associated D
+ORPHANET:308386	Sulfite oxidase deficiency due to molybdenum cofactor deficiency type A	ENSEMBL:ENSG00000124615	molybdenum cofactor synthesis 1
+ORPHANET:308393	Sulfite oxidase deficiency due to molybdenum cofactor deficiency type B	ENSEMBL:ENSG00000164172	molybdenum cofactor synthesis 2
+ORPHANET:308400	Sulfite oxidase deficiency due to molybdenum cofactor deficiency type C	ENSEMBL:ENSG00000171723	gephyrin
+ORPHANET:308410	Autism-epilepsy syndrome due to branched chain ketoacid dehydrogenase kinase deficiency	ENSEMBL:ENSG00000103507	branched chain keto acid dehydrogenase kinase
+ORPHANET:308425	Methylmalonic acidemia due to methylmalonyl-CoA epimerase deficiency	ENSEMBL:ENSG00000124370	methylmalonyl-CoA epimerase
+ORPHANET:308698	Glycogen storage disease due to glycogen branching enzyme deficiency, childhood neuromuscular form	ENSEMBL:ENSG00000114480	1,4-alpha-glucan branching enzyme 1
+ORPHANET:308712	Glycogen storage disease due to glycogen branching enzyme deficiency, adult neuromuscular form	ENSEMBL:ENSG00000114480	1,4-alpha-glucan branching enzyme 1
+ORPHANET:308670	Glycogen storage disease due to glycogen branching enzyme deficiency, congenital neuromuscular form	ENSEMBL:ENSG00000114480	1,4-alpha-glucan branching enzyme 1
+ORPHANET:308684	Glycogen storage disease due to glycogen branching enzyme deficiency, childhood combined hepatic and myopathic form	ENSEMBL:ENSG00000114480	1,4-alpha-glucan branching enzyme 1
+ORPHANET:309015	Familial lipoprotein lipase deficiency	ENSEMBL:ENSG00000175445	lipoprotein lipase
+ORPHANET:309020	Familial apolipoprotein C-II deficiency	ENSEMBL:ENSG00000234906	apolipoprotein C2
+ORPHANET:308487	Generalized galactose epimerase deficiency	ENSEMBL:ENSG00000117308	UDP-galactose-4-epimerase
+ORPHANET:178	Chordoma	ENSEMBL:ENSG00000164458	T-box transcription factor T
+ORPHANET:308473	Erythrocyte galactose epimerase deficiency	ENSEMBL:ENSG00000117308	UDP-galactose-4-epimerase
+ORPHANET:2637	Microcephalic osteodysplastic primordial dwarfism type II	ENSEMBL:ENSG00000160299	pericentrin
+ORPHANET:308442	Vitamin B12-responsive methylmalonic acidemia, type cblDv2	ENSEMBL:ENSG00000168288	metabolism of cobalamin associated D
+ORPHANET:308655	Glycogen storage disease due to glycogen branching enzyme deficiency, fatal perinatal neuromuscular form	ENSEMBL:ENSG00000114480	1,4-alpha-glucan branching enzyme 1
+ORPHANET:308638	Glycogen storage disease due to glycogen branching enzyme deficiency, non progressive hepatic form	ENSEMBL:ENSG00000114480	1,4-alpha-glucan branching enzyme 1
+ORPHANET:308621	Glycogen storage disease due to glycogen branching enzyme deficiency, progressive hepatic form	ENSEMBL:ENSG00000114480	1,4-alpha-glucan branching enzyme 1
+ORPHANET:308552	Glycogen storage disease due to acid maltase deficiency, infantile onset	ENSEMBL:ENSG00000171298	alpha glucosidase
+ORPHANET:309282	Alpha-mannosidosis, infantile form	ENSEMBL:ENSG00000104774	mannosidase alpha class 2B member 1
+ORPHANET:309288	Alpha-mannosidosis, adult form	ENSEMBL:ENSG00000104774	mannosidase alpha class 2B member 1
+ORPHANET:309246	GM2 gangliosidosis, AB variant	ENSEMBL:ENSG00000196743	ganglioside GM2 activator
+ORPHANET:309252	Atypical Gaucher disease due to saposin C deficiency	ENSEMBL:ENSG00000197746	prosaposin
+ORPHANET:309324	Free sialic acid storage disease, infantile form	ENSEMBL:ENSG00000119899	solute carrier family 17 member 5
+ORPHANET:309331	Intermediate severe Salla disease	ENSEMBL:ENSG00000119899	solute carrier family 17 member 5
+ORPHANET:309334	Salla disease	ENSEMBL:ENSG00000119899	solute carrier family 17 member 5
+ORPHANET:309297	Mucopolysaccharidosis type 4A	ENSEMBL:ENSG00000141012	galactosamine (N-acetyl)-6-sulfatase
+ORPHANET:309310	Mucopolysaccharidosis type 4B	ENSEMBL:ENSG00000170266	galactosidase beta 1
+ORPHANET:309185	Tay-Sachs disease, B variant, juvenile form	ENSEMBL:ENSG00000213614	hexosaminidase subunit alpha
+ORPHANET:309178	Tay-Sachs disease, B variant, infantile form	ENSEMBL:ENSG00000213614	hexosaminidase subunit alpha
+ORPHANET:309239	Tay-Sachs disease, B1 variant	ENSEMBL:ENSG00000213614	hexosaminidase subunit alpha
+ORPHANET:309192	Tay-Sachs disease, B variant, adult form	ENSEMBL:ENSG00000213614	hexosaminidase subunit alpha
+ORPHANET:309155	Sandhoff disease, infantile form	ENSEMBL:ENSG00000049860	hexosaminidase subunit beta
+ORPHANET:309169	Sandhoff disease, adult form	ENSEMBL:ENSG00000049860	hexosaminidase subunit beta
+ORPHANET:309162	Sandhoff disease, juvenile form	ENSEMBL:ENSG00000049860	hexosaminidase subunit beta
+ORPHANET:300570	Cortical dysgenesis with pontocerebellar hypoplasia due to TUBB3 mutation	ENSEMBL:ENSG00000258947	tubulin beta 3 class III
+ORPHANET:300573	Polymicrogyria due to TUBB2B mutation	ENSEMBL:ENSG00000137285	tubulin beta 2B class IIb
+ORPHANET:300576	Oligodontia-cancer predisposition syndrome	ENSEMBL:ENSG00000168646	axin 2
+ORPHANET:300496	Multiple congenital anomalies-hypotonia-seizures syndrome type 2	ENSEMBL:ENSG00000165195	phosphatidylinositol glycan anchor biosynthesis class A
+ORPHANET:300525	Pseudohypoaldosteronism type 2D	ENSEMBL:ENSG00000146021	kelch like family member 3
+ORPHANET:300530	Pseudohypoaldosteronism type 2E	ENSEMBL:ENSG00000036257	cullin 3
+ORPHANET:300536	DDOST-CDG	ENSEMBL:ENSG00000244038	dolichyl-diphosphooligosaccharide--protein glycosyltransferase non-catalytic subunit
+ORPHANET:300878	Hairy cell leukemia variant	ENSEMBL:ENSG00000211956	immunoglobulin heavy variable 4-34
+ORPHANET:300895	ALK-positive anaplastic large cell lymphoma	ENSEMBL:ENSG00000171094	ALK receptor tyrosine kinase
+ORPHANET:300751	Familial dilated cardiomyopathy with conduction defect due to LMNA mutation	ENSEMBL:ENSG00000160789	lamin A/C
+ORPHANET:306550	FADD-related immunodeficiency	ENSEMBL:ENSG00000168040	Fas associated via death domain
+ORPHANET:306542	Frontonasal dysplasia-severe microphthalmia-severe facial clefting syndrome	ENSEMBL:ENSG00000180318	ALX homeobox 1
+ORPHANET:306547	Porencephaly-microcephaly-bilateral congenital cataract syndrome	ENSEMBL:ENSG00000166086	junctional adhesion molecule 3
+ORPHANET:306530	Congenital hereditary facial paralysis-variable hearing loss syndrome	ENSEMBL:ENSG00000120094	homeobox B1
+ORPHANET:306511	Autosomal recessive spastic paraplegia type 48	ENSEMBL:ENSG00000242802	adaptor related protein complex 5 subunit zeta 1
+ORPHANET:306504	Interstitial lung disease-nephrotic syndrome-epidermolysis bullosa syndrome	ENSEMBL:ENSG00000005884	integrin subunit alpha 3
+ORPHANET:306658	Familial normophosphatemic tumoral calcinosis	ENSEMBL:ENSG00000205413	sterile alpha motif domain containing 9
+ORPHANET:306617	X-linked complicated spastic paraplegia type 1	ENSEMBL:ENSG00000198910	L1 cell adhesion molecule
+ORPHANET:295195	Synpolydactyly type 1	ENSEMBL:ENSG00000128714	homeobox D13
+ORPHANET:295191	Zygodactyly type 3	ENSEMBL:ENSG00000128714	homeobox D13
+ORPHANET:295201	Congenital vertical talus, unilateral	ENSEMBL:ENSG00000128710	homeobox D10
+ORPHANET:295203	Congenital vertical talus, bilateral	ENSEMBL:ENSG00000128710	homeobox D10
+ORPHANET:295197	Synpolydactyly type 2	ENSEMBL:ENSG00000077942	fibulin 1
+ORPHANET:295239	Macrodactyly of fingers, unilateral	ENSEMBL:ENSG00000121879	phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunit alpha
+ORPHANET:295243	Macrodactyly of toes, unilateral	ENSEMBL:ENSG00000121879	phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunit alpha
+ORPHANET:300179	Kyphoscoliotic Ehlers-Danlos syndrome due to FKBP22 deficiency	ENSEMBL:ENSG00000106080	FKBP prolyl isomerase 14
+ORPHANET:300319	Charcot-Marie-Tooth disease type 2P	ENSEMBL:ENSG00000148356	leucine rich repeat and sterile alpha motif containing 1
+ORPHANET:300324	Persistent polyclonal B-cell lymphocytosis	ENSEMBL:ENSG00000198286	caspase recruitment domain family member 11
+ORPHANET:300313	Congenital cataract-hearing loss-severe developmental delay syndrome	ENSEMBL:ENSG00000169359	solute carrier family 33 member 1
+ORPHANET:300298	Severe congenital hypochromic anemia with ringed sideroblasts	ENSEMBL:ENSG00000115107	STEAP3 metalloreductase
+ORPHANET:300284	Connective tissue disorder due to lysyl hydroxylase-3 deficiency	ENSEMBL:ENSG00000106397	procollagen-lysine,2-oxoglutarate 5-dioxygenase 3
+ORPHANET:300293	Transient infantile hypertriglyceridemia and hepatosteatosis	ENSEMBL:ENSG00000167588	glycerol-3-phosphate dehydrogenase 1
+ORPHANET:300382	Progeroid and marfanoid aspect-lipodystrophy syndrome	ENSEMBL:ENSG00000166147	fibrillin 1
+ORPHANET:300359	PLCG2-associated antibody deficiency and immune dysregulation	ENSEMBL:ENSG00000197943	phospholipase C gamma 2
+ORPHANET:300333	Nephrotic syndrome-epidermolysis bullosa-sensorineural deafness syndrome	ENSEMBL:ENSG00000177697	CD151 molecule (Raph blood group)
+ORPHANET:464738	Basel-Vanagaite-Smirin-Yosef syndrome	ENSEMBL:ENSG00000104973	mediator complex subunit 25
+ORPHANET:464760	Familial cavitary optic disc anomaly	ENSEMBL:ENSG00000123342	matrix metallopeptidase 19
+ORPHANET:464756	Familial gastric type 1 neuroendocrine tumor	ENSEMBL:ENSG00000105675	ATPase H+/K+ transporting subunit alpha
+ORPHANET:464282	Spastic paraplegia-severe developmental delay-epilepsy syndrome	ENSEMBL:ENSG00000085382	HECT domain and ankyrin repeat containing E3 ubiquitin protein ligase 1
+ORPHANET:464288	Short stature-brachydactyly-obesity-global developmental delay syndrome	ENSEMBL:ENSG00000132600	protein arginine methyltransferase 7
+ORPHANET:464311	Intellectual disability syndrome due to a DYRK1A point mutation	ENSEMBL:ENSG00000157540	dual specificity tyrosine phosphorylation regulated kinase 1A
+ORPHANET:464366	NEK9-related lethal skeletal dysplasia	ENSEMBL:ENSG00000119638	NIMA related kinase 9
+ORPHANET:464336	BENTA disease	ENSEMBL:ENSG00000198286	caspase recruitment domain family member 11
+ORPHANET:464443	COG6-CGD	ENSEMBL:ENSG00000133103	component of oligomeric golgi complex 6
+ORPHANET:464440	Primary dystonia, DYT27 type	ENSEMBL:ENSG00000163359	collagen type VI alpha 3 chain
+ORPHANET:464370	Neonatal alloimmune neutropenia	ENSEMBL:ENSG00000162747	Fc fragment of IgG receptor IIIb
+ORPHANET:456333	Hereditary neuroendocrine tumor of small intestine	ENSEMBL:ENSG00000151151	inositol polyphosphate multikinase
+ORPHANET:456312	Infantile multisystem neurologic-endocrine-pancreatic disease	ENSEMBL:ENSG00000141378	peptidyl-tRNA hydrolase 2
+ORPHANET:456318	Hereditary sensory neuropathy-deafness-dementia syndrome	ENSEMBL:ENSG00000130816	DNA methyltransferase 1
+ORPHANET:454840	NTHL1-related attenuated familial adenomatous polyposis	ENSEMBL:ENSG00000065057	nth like DNA glycosylase 1
+ORPHANET:454745	Kuru	ENSEMBL:ENSG00000171867	prion protein
+ORPHANET:453533	Polyendocrine-polyneuropathy syndrome	ENSEMBL:ENSG00000104093	Dmx like 2
+ORPHANET:453521	Autosomal recessive cerebellar ataxia due to CWF19L1 deficiency	ENSEMBL:ENSG00000095485	CWF19 like cell cycle control factor 1
+ORPHANET:451612	Familial congenital nasolacrimal duct obstruction	ENSEMBL:ENSG00000143061	immunoglobulin superfamily member 3
+ORPHANET:453504	Neurodevelopmental disorder-craniofacial dysmorphism-cardiac defect-skeletal anomalies syndrome due to a point mutation	ENSEMBL:ENSG00000165119	heterogeneous nuclear ribonucleoprotein K
+ORPHANET:453510	Congenital insensitivity to pain with severe intellectual disability	ENSEMBL:ENSG00000070371	clathrin heavy chain like 1
+ORPHANET:449291	Symptomatic form of fragile X syndrome in female carriers	ENSEMBL:ENSG00000102081	fragile X messenger ribonucleoprotein 1
+ORPHANET:449262	NON RARE IN EUROPE: Primary bile acid malabsorption	ENSEMBL:ENSG00000125255	solute carrier family 10 member 2
+ORPHANET:448251	Progressive autosomal recessive ataxia-deafness syndrome	ENSEMBL:ENSG00000090020	solute carrier family 9 member A1
+ORPHANET:448267	Regressive spondylometaphyseal dysplasia	ENSEMBL:ENSG00000143815	lamin B receptor
+ORPHANET:448010	CAD-CDG	ENSEMBL:ENSG00000084774	carbamoyl-phosphate synthetase 2, aspartate transcarbamylase, and dihydroorotase
+ORPHANET:447997	Spastic tetraplegia-thin corpus callosum-progressive postnatal microcephaly syndrome	ENSEMBL:ENSG00000115902	solute carrier family 1 member 4
+ORPHANET:448242	Autosomal recessive brachyolmia	ENSEMBL:ENSG00000198682	3'-phosphoadenosine 5'-phosphosulfate synthase 2
+ORPHANET:447977	Progressive scapulohumeroperoneal distal myopathy	ENSEMBL:ENSG00000143632	actin alpha 1, skeletal muscle
+ORPHANET:447974	Klippel-Feil anomaly-myopathy-facial dysmorphism syndrome	ENSEMBL:ENSG00000133454	myosin XVIIIB
+ORPHANET:447980	19p13.3 microduplication syndrome	ENSEMBL:ENSG00000008441	nuclear factor I X
+ORPHANET:447954	Combined oxidative phosphorylation defect type 25	ENSEMBL:ENSG00000247626	methionyl-tRNA synthetase 2, mitochondrial
+ORPHANET:447964	Autosomal dominant Charcot-Marie-Tooth disease type 2V	ENSEMBL:ENSG00000108784	N-acetyl-alpha-glucosaminidase
+ORPHANET:447961	Pigmentation defects-palmoplantar keratoderma-skin carcinoma syndrome	ENSEMBL:ENSG00000111961	SAM and SH3 domain containing 1
+ORPHANET:459033	Ataxia-oculomotor apraxia type 4	ENSEMBL:ENSG00000039650	polynucleotide kinase 3'-phosphatase
+ORPHANET:459051	Spondyloepiphyseal dysplasia, Stanescu type	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:459061	Craniofacial dysplasia-short stature-ectodermal anomalies-intellectual disability syndrome	ENSEMBL:ENSG00000108963	diphthamide biosynthesis 1
+ORPHANET:459056	Autosomal recessive spastic paraplegia type 75	ENSEMBL:ENSG00000105695	myelin associated glycoprotein
+ORPHANET:459070	X-linked intellectual disability-cerebellar hypoplasia-spondylo-epiphyseal dysplasia syndrome	ENSEMBL:ENSG00000147403	ribosomal protein L10
+ORPHANET:458713	NON RARE IN EUROPE: Specific language impairment	ENSEMBL:ENSG00000170448	nuclear transcription factor, X-box binding like 1
+ORPHANET:458798	Spinocerebellar ataxia type 41	ENSEMBL:ENSG00000138741	transient receptor potential cation channel subfamily C member 3
+ORPHANET:458803	Spinocerebellar ataxia type 42	ENSEMBL:ENSG00000006283	calcium voltage-gated channel subunit alpha1 G
+ORPHANET:457485	Macrocephaly-intellectual disability-neurodevelopmental disorder-small thorax syndrome	ENSEMBL:ENSG00000198793	mechanistic target of rapamycin kinase
+ORPHANET:457265	Progressive myoclonic epilepsy type 9	ENSEMBL:ENSG00000176619	lamin B2
+ORPHANET:457279	Intellectual disability-macrocephaly-hypotonia-behavioral abnormalities syndrome	ENSEMBL:ENSG00000112640	protein phosphatase 2 regulatory subunit B'delta
+ORPHANET:457260	X-linked intellectual disability-hypotonia-movement disorder syndrome	ENSEMBL:ENSG00000215301	DEAD-box helicase 3 X-linked
+ORPHANET:457240	X-linked intellectual disability-short stature-overweight syndrome	ENSEMBL:ENSG00000125676	THO complex subunit 2
+ORPHANET:457395	Progressive spondyloepimetaphyseal dysplasia-short stature-short fourth metatarsals-intellectual disability syndrome	ENSEMBL:ENSG00000159579	ring finger and SPRY domain containing 1
+ORPHANET:457406	Multiple mitochondrial dysfunctions syndrome type 4	ENSEMBL:ENSG00000165898	iron-sulfur cluster assembly 2
+ORPHANET:457375	ITPA-related lethal infantile neurological disorder with cataract and cardiac involvement	ENSEMBL:ENSG00000125877	inosine triphosphatase
+ORPHANET:457378	Complex lethal osteochondrodysplasia	ENSEMBL:ENSG00000169762	transmembrane anterior posterior transformation 1
+ORPHANET:457359	Megalencephaly-severe kyphoscoliosis-overgrowth syndrome	ENSEMBL:ENSG00000103657	HECT and RLD domain containing E3 ubiquitin protein ligase family member 1
+ORPHANET:457284	Microcephaly-corpus callosum hypoplasia-intellectual disability-facial dysmorphism syndrome	ENSEMBL:ENSG00000105568	protein phosphatase 2 scaffold subunit Aalpha
+ORPHANET:457351	Microcephaly-intellectual disability-sensorineural hearing loss-epilepsy-abnormal muscle tone syndrome	ENSEMBL:ENSG00000145375	spermatogenesis associated 5
+ORPHANET:457185	Neonatal encephalomyopathy-cardiomyopathy-respiratory distress syndrome	ENSEMBL:ENSG00000167113	coenzyme Q4
+ORPHANET:457088	Predisposition to invasive fungal disease due to CARD9 deficiency	ENSEMBL:ENSG00000187796	caspase recruitment domain family member 9
+ORPHANET:457223	Syndromic sensorineural deafness due to combined oxidative phosphorylation defect	ENSEMBL:ENSG00000125445	mitochondrial ribosomal protein S7
+ORPHANET:457212	Progressive essential tremor-speech impairment-facial dysmorphism-intellectual disability-abnormal behavior syndrome	ENSEMBL:ENSG00000197106	solute carrier family 6 member 17
+ORPHANET:457193	Autosomal dominant intellectual disability-craniofacial anomalies-cardiac defects syndrome	ENSEMBL:ENSG00000083168	lysine acetyltransferase 6A
+ORPHANET:456369	Polyglucosan body myopathy type 2	ENSEMBL:ENSG00000163754	glycogenin 1
+ORPHANET:457050	Autosomal dominant mitochondrial myopathy with exercise intolerance	ENSEMBL:ENSG00000250479	coiled-coil-helix-coiled-coil-helix domain containing 10
+ORPHANET:629	Short stature due to growth hormone qualitative anomaly	ENSEMBL:ENSG00000259384	growth hormone 1
+ORPHANET:198	Occipital horn syndrome	ENSEMBL:ENSG00000165240	ATPase copper transporting alpha
+ORPHANET:466688	Severe intellectual disability-corpus callosum agenesis-facial dysmorphism-cerebellar ataxia syndrome	ENSEMBL:ENSG00000151474	FERM domain containing 4A
+ORPHANET:466650	Exercise-induced malignant hyperthermia	ENSEMBL:ENSG00000196218	ryanodine receptor 1
+ORPHANET:466962	SMARCA4-deficient sarcoma of thorax	ENSEMBL:ENSG00000127616	SWI/SNF related, matrix associated, actin dependent regulator of chromatin, subfamily a, member 4
+ORPHANET:466950	Facial dysmorphism-developmental delay-behavioral abnormalities syndrome due to WAC point mutation	ENSEMBL:ENSG00000095787	WW domain containing adaptor with coiled-coil
+ORPHANET:466926	Seizures-scoliosis-macrocephaly syndrome	ENSEMBL:ENSG00000151348	exostosin glycosyltransferase 2
+ORPHANET:466934	VPS11-related autosomal recessive hypomyelinating leukodystrophy	ENSEMBL:ENSG00000160695	VPS11 core subunit of CORVET and HOPS complexes
+ORPHANET:466921	Childhood-onset progressive contractures-limb-girdle weakness-muscle dystrophy syndrome	ENSEMBL:ENSG00000155657	titin
+ORPHANET:466806	Autosomal dominant thrombocytopenia with platelet secretion defect	ENSEMBL:ENSG00000236320	schlafen family member 14
+ORPHANET:466801	LIMS2-related limb-girdle muscular dystrophy	ENSEMBL:ENSG00000072163	LIM zinc finger domain containing 2
+ORPHANET:466794	Acute infantile liver failure-cerebellar ataxia-peripheral sensory motor neuropathy syndrome	ENSEMBL:ENSG00000142186	SCY1 like pseudokinase 1
+ORPHANET:466791	Macrocephaly-intellectual disability-left ventricular non compaction syndrome	ENSEMBL:ENSG00000147140	non-POU domain containing octamer binding
+ORPHANET:466784	Neonatal severe cardiopulmonary failure due to mitochondrial methylation defect	ENSEMBL:ENSG00000144741	solute carrier family 25 member 26
+ORPHANET:466775	Autosomal recessive Charcot-Marie-Tooth disease type 2X	ENSEMBL:ENSG00000104133	SPG11 vesicle trafficking associated, spatacsin
+ORPHANET:466768	Autosomal dominant Charcot-Marie-Tooth disease type 2Z	ENSEMBL:ENSG00000133422	MORC family CW-type zinc finger 2
+ORPHANET:466722	Autosomal recessive spastic paraplegia type 77	ENSEMBL:ENSG00000145982	phenylalanyl-tRNA synthetase 2, mitochondrial
+ORPHANET:466718	Martinique crinkled retinal pigment epitheliopathy	ENSEMBL:ENSG00000114738	MAPK activated protein kinase 3
+ORPHANET:466703	TMEM199-CDG	ENSEMBL:ENSG00000244045	transmembrane protein 199
+ORPHANET:465824	Fetal encasement syndrome	ENSEMBL:ENSG00000213341	component of inhibitor of nuclear factor kappa B kinase complex
+ORPHANET:466026	Class I glucose-6-phosphate dehydrogenase deficiency	ENSEMBL:ENSG00000160211	glucose-6-phosphate dehydrogenase
+ORPHANET:468620	Intellectual disability-epilepsy-extrapyramidal syndrome	ENSEMBL:ENSG00000177030	DEAF1 transcription factor
+ORPHANET:468631	Microcephalic cortical malformations-short stature due to RTTN deficiency	ENSEMBL:ENSG00000176225	rotatin
+ORPHANET:467176	Severe hypotonia-psychomotor developmental delay-strabismus-cardiac septal defect syndrome	ENSEMBL:ENSG00000154781	coiled-coil domain containing 174
+ORPHANET:468635	Cryptogenic multifocal ulcerous stenosing enteritis	ENSEMBL:ENSG00000116711	phospholipase A2 group IVA
+ORPHANET:468641	Chronic enteropathy associated with SLCO2A1 gene	ENSEMBL:ENSG00000174640	solute carrier organic anion transporter family member 2A1
+ORPHANET:468661	Autosomal recessive spastic paraplegia type 74	ENSEMBL:ENSG00000181873	iron-sulfur cluster assembly factor IBA57
+ORPHANET:468666	Isolated generalized anhidrosis with normal sweat glands	ENSEMBL:ENSG00000123104	inositol 1,4,5-trisphosphate receptor type 2
+ORPHANET:468678	White-Sutton syndrome	ENSEMBL:ENSG00000143442	pogo transposable element derived with ZNF domain
+ORPHANET:468684	CCDC115-CDG	ENSEMBL:ENSG00000136710	coiled-coil domain containing 115
+ORPHANET:468672	Colobomatous macrophthalmia-microcornea syndrome	ENSEMBL:ENSG00000150938	cysteine rich transmembrane BMP regulator 1
+ORPHANET:468726	Severe primary trimethylaminuria	ENSEMBL:ENSG00000007933	flavin containing dimethylaniline monoxygenase 3
+ORPHANET:468699	SLC39A8-CDG	ENSEMBL:ENSG00000138821	solute carrier family 39 member 8
+ORPHANET:468717	Rhizomelic chondrodysplasia punctata type 5	ENSEMBL:ENSG00000139197	peroxisomal biogenesis factor 5
+ORPHANET:401785	Autosomal recessive spastic paraplegia type 62	ENSEMBL:ENSG00000107566	ER lipid raft associated 1
+ORPHANET:401780	Autosomal recessive spastic paraplegia type 61	ENSEMBL:ENSG00000170540	ADP ribosylation factor like GTPase 6 interacting protein 1
+ORPHANET:401800	Autosomal recessive spastic paraplegia type 60	ENSEMBL:ENSG00000114742	WD repeat domain 48
+ORPHANET:401795	Autosomal recessive spastic paraplegia type 59	ENSEMBL:ENSG00000138592	ubiquitin specific peptidase 8
+ORPHANET:401768	Proximal myopathy with extrapyramidal signs	ENSEMBL:ENSG00000107745	mitochondrial calcium uptake 1
+ORPHANET:401764	Pancytopenia-developmental delay syndrome	ENSEMBL:ENSG00000182150	ERCC excision repair 6 like 2
+ORPHANET:401777	Optic atrophy-intellectual disability syndrome	ENSEMBL:ENSG00000175745	nuclear receptor subfamily 2 group F member 1
+ORPHANET:401830	Autosomal recessive spastic paraplegia type 69	ENSEMBL:ENSG00000118873	RAB3 GTPase activating non-catalytic protein subunit 2
+ORPHANET:401835	Autosomal recessive spastic paraplegia type 70	ENSEMBL:ENSG00000166986	methionyl-tRNA synthetase 1
+ORPHANET:401840	Autosomal recessive spastic paraplegia type 71	ENSEMBL:ENSG00000056097	zinc finger RNA binding protein
+ORPHANET:401805	Autosomal recessive spastic paraplegia type 63	ENSEMBL:ENSG00000116337	adenosine monophosphate deaminase 2
+ORPHANET:401810	Autosomal recessive spastic paraplegia type 64	ENSEMBL:ENSG00000138185	ectonucleoside triphosphate diphosphohydrolase 1
+ORPHANET:401815	Autosomal recessive spastic paraplegia type 66	ENSEMBL:ENSG00000183876	arylsulfatase family member I
+ORPHANET:401820	Autosomal recessive spastic paraplegia type 67	ENSEMBL:ENSG00000197121	post-GPI attachment to proteins inositol deacylase 1
+ORPHANET:401866	Childhood-onset spasticity with hyperglycinemia	ENSEMBL:ENSG00000182512	glutaredoxin 5
+ORPHANET:401869	Multiple mitochondrial dysfunctions syndrome type 1	ENSEMBL:ENSG00000169599	NFU1 iron-sulfur cluster scaffold
+ORPHANET:401874	Multiple mitochondrial dysfunctions syndrome type 2	ENSEMBL:ENSG00000163170	bolA family member 3
+ORPHANET:401849	Autosomal spastic paraplegia type 72	ENSEMBL:ENSG00000132563	receptor accessory protein 2
+ORPHANET:401859	Lipoic acid synthetase deficiency	ENSEMBL:ENSG00000121897	lipoic acid synthetase
+ORPHANET:401862	Lipoyl transferase 1 deficiency	ENSEMBL:ENSG00000144182	lipoyltransferase 1
+ORPHANET:401911	AXIN2-related attenuated familial adenomatous polyposis	ENSEMBL:ENSG00000168646	axin 2
+ORPHANET:401901	Huntington disease-like syndrome due to C9ORF72 expansions	ENSEMBL:ENSG00000147894	C9orf72-SMCR8 complex subunit
+ORPHANET:401959	Partial corpus callosum agenesis-cerebellar vermis hypoplasia with posterior fossa cysts syndrome	ENSEMBL:ENSG00000185467	karyopherin subunit alpha 7
+ORPHANET:401948	Hyperammonemic encephalopathy due to carbonic anhydrase VA deficiency	ENSEMBL:ENSG00000174990	carbonic anhydrase 5A
+ORPHANET:401945	Moyamoya disease with early-onset achalasia	ENSEMBL:ENSG00000164116	guanylate cyclase 1 soluble subunit alpha 1
+ORPHANET:401986	1p31p32 microdeletion syndrome	ENSEMBL:ENSG00000162599	nuclear factor I A
+ORPHANET:401979	Autosomal recessive spondylometaphyseal dysplasia, Mégarbané type	ENSEMBL:ENSG00000217930	presequence translocase associated motor 16
+ORPHANET:401973	MEND syndrome	ENSEMBL:ENSG00000147155	EBP cholestenol delta-isomerase
+ORPHANET:401964	Autosomal dominant Charcot-Marie-Tooth disease type 2 with giant axons	ENSEMBL:ENSG00000132716	DDB1 and CUL4 associated factor 8
+ORPHANET:402003	Autosomal dominant focal non-epidermolytic palmoplantar keratoderma with plantar blistering	ENSEMBL:ENSG00000170465	keratin 6C
+ORPHANET:401996	Karyomegalic interstitial nephritis	ENSEMBL:ENSG00000198690	FANCD2 and FANCI associated nuclease 1
+ORPHANET:402026	Acute myeloid leukemia with NPM1 somatic mutations	ENSEMBL:ENSG00000181163	nucleophosmin 1
+ORPHANET:402364	Infantile cerebral and cerebellar atrophy with postnatal progressive microcephaly	ENSEMBL:ENSG00000042429	mediator complex subunit 17
+ORPHANET:806	Scott syndrome	ENSEMBL:ENSG00000177119	anoctamin 6
+ORPHANET:404473	Severe intellectual disability-progressive spastic diplegia syndrome	ENSEMBL:ENSG00000168036	catenin beta 1
+ORPHANET:404463	Multisystemic smooth muscle dysfunction syndrome	ENSEMBL:ENSG00000107796	actin alpha 2, smooth muscle
+ORPHANET:404451	FBLN1-related developmental delay-central nervous system anomaly-syndactyly syndrome	ENSEMBL:ENSG00000077942	fibulin 1
+ORPHANET:404454	Alacrimia-choreoathetosis-liver dysfunction syndrome	ENSEMBL:ENSG00000151092	N-glycanase 1
+ORPHANET:404443	Tatton-Brown-Rahman syndrome	ENSEMBL:ENSG00000119772	DNA methyltransferase 3 alpha
+ORPHANET:404448	ADNP syndrome	ENSEMBL:ENSG00000101126	activity dependent neuroprotector homeobox
+ORPHANET:404437	Diffuse cerebral and cerebellar atrophy-intractable seizures-progressive microcephaly syndrome	ENSEMBL:ENSG00000172053	glutaminyl-tRNA synthetase 1
+ORPHANET:404440	Intellectual disability-facial dysmorphism syndrome due to SETD5 haploinsufficiency	ENSEMBL:ENSG00000168137	SET domain containing 5
+ORPHANET:404560	Familial atypical multiple mole melanoma syndrome	ENSEMBL:ENSG00000147889	cyclin dependent kinase inhibitor 2A
+ORPHANET:404553	Vasculitis due to ADA2 deficiency	ENSEMBL:ENSG00000093072	adenosine deaminase 2
+ORPHANET:404546	DITRA	ENSEMBL:ENSG00000136695	interleukin 36 receptor antagonist
+ORPHANET:404521	Spinal muscular atrophy with respiratory distress type 2	ENSEMBL:ENSG00000001497	LAS1 like ribosome biogenesis factor
+ORPHANET:404507	Chondromyxoid fibroma	ENSEMBL:ENSG00000152822	glutamate metabotropic receptor 1
+ORPHANET:404499	Autosomal recessive cerebellar ataxia-epilepsy-intellectual disability syndrome due to RUBCN deficiency	ENSEMBL:ENSG00000145016	rubicon autophagy regulator
+ORPHANET:404493	Autosomal recessive cerebellar ataxia-epilepsy-intellectual disability syndrome due to TUD deficiency	ENSEMBL:ENSG00000111802	tyrosyl-DNA phosphodiesterase 2
+ORPHANET:404476	Global developmental delay-lung cysts-overgrowth-Wilms tumor syndrome	ENSEMBL:ENSG00000100697	dicer 1, ribonuclease III
+ORPHANET:411536	Mild phosphoribosylpyrophosphate synthetase superactivity	ENSEMBL:ENSG00000147224	phosphoribosyl pyrophosphate synthetase 1
+ORPHANET:411543	Severe phosphoribosylpyrophosphate synthetase superactivity	ENSEMBL:ENSG00000147224	phosphoribosyl pyrophosphate synthetase 1
+ORPHANET:411590	Wolfram-like syndrome	ENSEMBL:ENSG00000109501	wolframin ER transmembrane glycoprotein
+ORPHANET:411629	Infantile nephropathic cystinosis	ENSEMBL:ENSG00000040531	cystinosin, lysosomal cystine transporter
+ORPHANET:411493	Pontocerebellar hypoplasia type 10	ENSEMBL:ENSG00000172409	cleavage factor polyribonucleotide kinase subunit 1
+ORPHANET:411511	Angelman syndrome due to a point mutation	ENSEMBL:ENSG00000114062	ubiquitin protein ligase E3A
+ORPHANET:411712	Maternal riboflavin deficiency	ENSEMBL:ENSG00000132517	solute carrier family 52 member 1
+ORPHANET:411788	Familial isolated trichomegaly	ENSEMBL:ENSG00000138675	fibroblast growth factor 5
+ORPHANET:411986	Early-onset epileptic encephalopathy-cortical blindness-intellectual disability-facial dysmorphism syndrome	ENSEMBL:ENSG00000116641	dedicator of cytokinesis 7
+ORPHANET:412022	Facial dysmorphism-lens dislocation-anterior segment abnormalities-spontaneous filtering blebs syndrome	ENSEMBL:ENSG00000198363	aspartate beta-hydroxylase
+ORPHANET:411641	Ocular cystinosis	ENSEMBL:ENSG00000040531	cystinosin, lysosomal cystine transporter
+ORPHANET:411634	Juvenile nephropathic cystinosis	ENSEMBL:ENSG00000040531	cystinosin, lysosomal cystine transporter
+ORPHANET:391677	Short stature-optic atrophy-Pelger-Huët anomaly syndrome	ENSEMBL:ENSG00000151779	NBAS subunit of NRZ tethering complex
+ORPHANET:391474	Frontorhiny	ENSEMBL:ENSG00000156150	ALX homeobox 3
+ORPHANET:391646	Feingold syndrome type 2	ENSEMBL:ENSG00000215417	miR-17-92a-1 cluster host gene
+ORPHANET:391641	Feingold syndrome type 1	ENSEMBL:ENSG00000134323	MYCN proto-oncogene, bHLH transcription factor
+ORPHANET:391343	Fatal post-viral neurodegenerative disorder	ENSEMBL:ENSG00000180644	perforin 1
+ORPHANET:391348	Growth and developmental delay-hypotonia-vision impairment-lactic acidosis syndrome	ENSEMBL:ENSG00000183605	sideroflexin 4
+ORPHANET:391351	SURF1-related Charcot-Marie-Tooth disease type 4	ENSEMBL:ENSG00000148290	SURF1 cytochrome c oxidase assembly factor
+ORPHANET:391366	Growth retardation-mild developmental delay-chronic hepatitis syndrome	ENSEMBL:ENSG00000111252	SH2B adaptor protein 3
+ORPHANET:391372	Intellectual disability-severe speech delay-mild dysmorphism syndrome	ENSEMBL:ENSG00000114861	forkhead box P1
+ORPHANET:391376	Congenital microcephaly-severe encephalopathy-progressive cerebral atrophy syndrome	ENSEMBL:ENSG00000070669	asparagine synthetase (glutamine-hydrolyzing)
+ORPHANET:391389	Familial episodic pain syndrome with predominantly upper body involvement	ENSEMBL:ENSG00000104321	transient receptor potential cation channel subfamily A member 1
+ORPHANET:391392	Familial episodic pain syndrome with predominantly lower limb involvement	ENSEMBL:ENSG00000168356	sodium voltage-gated channel alpha subunit 11
+ORPHANET:391397	Hereditary sensory and autonomic neuropathy type 7	ENSEMBL:ENSG00000168356	sodium voltage-gated channel alpha subunit 11
+ORPHANET:391428	HSD10 disease, infantile type	ENSEMBL:ENSG00000072506	hydroxysteroid 17-beta dehydrogenase 10
+ORPHANET:391457	HSD10 disease, neonatal type	ENSEMBL:ENSG00000072506	hydroxysteroid 17-beta dehydrogenase 10
+ORPHANET:391307	Severe intellectual disability-short stature-behavioral abnormalities-facial dysmorphism syndrome	ENSEMBL:ENSG00000129696	TELO2 interacting protein 2
+ORPHANET:391316	Infantile-onset mesial temporal lobe epilepsy with severe cognitive regression	ENSEMBL:ENSG00000061938	tyrosine kinase non receptor 2
+ORPHANET:391311	Susceptibility to viral and mycobacterial infections due to STAT1 deficiency	ENSEMBL:ENSG00000115415	signal transducer and activator of transcription 1
+ORPHANET:391320	East Texas bleeding disorder	ENSEMBL:ENSG00000198734	coagulation factor V
+ORPHANET:391330	X-linked osteoporosis with fractures	ENSEMBL:ENSG00000102024	plastin 3
+ORPHANET:397968	Charcot-Marie-Tooth disease type 2R	ENSEMBL:ENSG00000109654	tripartite motif containing 2
+ORPHANET:397964	Combined immunodeficiency due to MALT1 deficiency	ENSEMBL:ENSG00000172175	MALT1 paracaspase
+ORPHANET:397959	TCR-alpha-beta-positive T-cell deficiency	ENSEMBL:ENSG00000277734	T-cell receptor alpha constant
+ORPHANET:397951	Microcephaly-thin corpus callosum-intellectual disability syndrome	ENSEMBL:ENSG00000064313	TATA-box binding protein associated factor 2
+ORPHANET:397946	Autosomal spastic paraplegia type 58	ENSEMBL:ENSG00000129250	kinesin family member 1C
+ORPHANET:397941	MAN1B1-CDG	ENSEMBL:ENSG00000177239	mannosidase alpha class 1B member 1
+ORPHANET:397937	Polyglucosan body myopathy type 1	ENSEMBL:ENSG00000125826	RANBP2-type and C3HC4-type zinc finger containing 1
+ORPHANET:397933	Severe intellectual disability-progressive postnatal microcephaly-midline stereotypic hand movements syndrome	ENSEMBL:ENSG00000124313	IQ motif and Sec7 domain ArfGEF 2
+ORPHANET:397927	Sacral agenesis-abnormal ossification of the vertebral bodies-persistent notochordal canal syndrome	ENSEMBL:ENSG00000164458	T-box transcription factor T
+ORPHANET:397922	Ferro-cerebro-cutaneous syndrome	ENSEMBL:ENSG00000165195	phosphatidylinositol glycan anchor biosynthesis class A
+ORPHANET:397787	Severe combined immunodeficiency due to IKK2 deficiency	ENSEMBL:ENSG00000104365	inhibitor of nuclear factor kappa B kinase subunit beta
+ORPHANET:397755	Periodic paralysis with transient compartment-like syndrome	ENSEMBL:ENSG00000081248	calcium voltage-gated channel subunit alpha1 S
+ORPHANET:397758	Retinal dystrophy with inner retinal dysfunction and ganglion cell anomalies	ENSEMBL:ENSG00000136156	integral membrane protein 2B
+ORPHANET:397744	Peripheral neuropathy-myopathy-hoarseness-hearing loss syndrome	ENSEMBL:ENSG00000105357	myosin heavy chain 14
+ORPHANET:397725	COASY protein-associated neurodegeneration	ENSEMBL:ENSG00000068120	Coenzyme A synthase
+ORPHANET:397735	Autosomal dominant Charcot-Marie-Tooth disease type 2U	ENSEMBL:ENSG00000166986	methionyl-tRNA synthetase 1
+ORPHANET:397709	Intellectual disability-coarse face-macrocephaly-cerebellar hypotrophy syndrome	ENSEMBL:ENSG00000135317	sorting nexin 14
+ORPHANET:397623	Short stature-auditory canal atresia-mandibular hypoplasia-skeletal anomalies syndrome	ENSEMBL:ENSG00000133937	goosecoid homeobox
+ORPHANET:397685	Familial hyperprolactinemia	ENSEMBL:ENSG00000113494	prolactin receptor
+ORPHANET:397615	Obesity due to CEP19 deficiency	ENSEMBL:ENSG00000174007	centrosomal protein 19
+ORPHANET:397618	Foveal hypoplasia-optic nerve decussation defect-anterior segment dysgenesis syndrome	ENSEMBL:ENSG00000166558	solute carrier family 38 member 8
+ORPHANET:397612	Macrocephaly-developmental delay syndrome	ENSEMBL:ENSG00000118162	kaptin, actin binding protein
+ORPHANET:397606	PrP systemic amyloidosis	ENSEMBL:ENSG00000171867	prion protein
+ORPHANET:399808	Male infertility with teratozoospermia due to single gene mutation	ENSEMBL:ENSG00000188613	nanos C2HC-type zinc finger 1
+ORPHANET:399058	Alpha-B crystallin-related late-onset myopathy	ENSEMBL:ENSG00000109846	crystallin alpha B
+ORPHANET:399081	KLHL9-related early-onset distal myopathy	ENSEMBL:ENSG00000198642	kelch like family member 9
+ORPHANET:399103	Distal nebulin myopathy	ENSEMBL:ENSG00000183091	nebulin
+ORPHANET:399096	Distal anoctaminopathy	ENSEMBL:ENSG00000171714	anoctamin 5
+ORPHANET:398189	Focal facial dermal dysplasia type IV	ENSEMBL:ENSG00000187553	cytochrome P450 family 26 subfamily C member 1
+ORPHANET:398069	MAGEL2-related Prader-Willi-like syndrome	ENSEMBL:ENSG00000254585	MAGE family member L2
+ORPHANET:398079	SIM1-related Prader-Willi-like syndrome	ENSEMBL:ENSG00000112246	SIM bHLH transcription factor 1
+ORPHANET:398088	Hereditary cryohydrocytosis with normal stomatin	ENSEMBL:ENSG00000004939	solute carrier family 4 member 1 (Diego blood group)
+ORPHANET:435628	Keppen-Lubinsky syndrome	ENSEMBL:ENSG00000157542	potassium inwardly rectifying channel subfamily J member 6
+ORPHANET:435660	LIPE-related familial partial lipodystrophy	ENSEMBL:ENSG00000079435	lipase E, hormone sensitive type
+ORPHANET:435651	CIDEC-related familial partial lipodystrophy	ENSEMBL:ENSG00000187288	cell death inducing DFFA like effector c
+ORPHANET:435804	Short stature-advanced bone age-early-onset osteoarthritis syndrome	ENSEMBL:ENSG00000157766	aggrecan
+ORPHANET:435845	Lethal neonatal spasticity-epileptic encephalopathy syndrome	ENSEMBL:ENSG00000106009	BRCA1 associated ATM activator 1
+ORPHANET:435930	Colobomatous optic disc-macular atrophy-chorioretinopathy syndrome	ENSEMBL:ENSG00000184302	SIX homeobox 6
+ORPHANET:435819	Autosomal dominant Charcot-Marie-Tooth disease type 2 due to TFG mutation	ENSEMBL:ENSG00000114354	trafficking from ER to golgi regulator
+ORPHANET:435953	Progeroid features-hepatocellular carcinoma predisposition syndrome	ENSEMBL:ENSG00000010072	SprT-like N-terminal domain
+ORPHANET:435988	Chronic atrial and intestinal dysrhythmia syndrome	ENSEMBL:ENSG00000129810	shugoshin 1
+ORPHANET:435934	COG2-CDG	ENSEMBL:ENSG00000135775	component of oligomeric golgi complex 2
+ORPHANET:435938	X-linked microcephaly-growth retardation-prognathism-cryptorchidism syndrome	ENSEMBL:ENSG00000147403	ribosomal protein L10
+ORPHANET:436144	Intrauterine growth restriction-short stature-early adult-onset diabetes syndrome	ENSEMBL:ENSG00000129757	cyclin dependent kinase inhibitor 1C
+ORPHANET:435998	Autosomal recessive intermediate Charcot-Marie-Tooth disease type D	ENSEMBL:ENSG00000111775	cytochrome c oxidase subunit 6A1
+ORPHANET:436159	Autoimmune lymphoproliferative syndrome due to CTLA4 haploinsuffiency	ENSEMBL:ENSG00000163599	cytotoxic T-lymphocyte associated protein 4
+ORPHANET:436151	Intellectual disability-expressive aphasia-facial dysmorphism syndrome	ENSEMBL:ENSG00000152217	SET binding protein 1
+ORPHANET:436169	Thrombomodulin-related bleeding disorder	ENSEMBL:ENSG00000178726	thrombomodulin
+ORPHANET:436166	Periodic fever-infantile enterocolitis-autoinflammatory syndrome	ENSEMBL:ENSG00000091106	NLR family CARD domain containing 4
+ORPHANET:436174	Cataract-growth hormone deficiency-sensory neuropathy-sensorineural hearing loss-skeletal dysplasia syndrome	ENSEMBL:ENSG00000067704	isoleucyl-tRNA synthetase 2, mitochondrial
+ORPHANET:436245	Retinitis pigmentosa-juvenile cataract-short stature-intellectual disability syndrome	ENSEMBL:ENSG00000072042	retinol dehydrogenase 11
+ORPHANET:436242	Familial atrial tachyarrhythmia-infra-Hisian cardiac conduction disease	ENSEMBL:ENSG00000116783	TNNI3 interacting kinase
+ORPHANET:436271	Non-progressive predominantly posterior cavitating leukoencephalopathy with peripheral neuropathy	ENSEMBL:ENSG00000256053	cytochrome c oxidase assembly factor 8
+ORPHANET:436274	Pseudoxanthoma elasticum-like skin manifestations with retinitis pigmentosa	ENSEMBL:ENSG00000115486	gamma-glutamyl carboxylase
+ORPHANET:437552	Autosomal recessive primary immunodeficiency with defective spontaneous natural killer cell cytotoxicity	ENSEMBL:ENSG00000203747	Fc fragment of IgG receptor IIIa
+ORPHANET:437572	MYH7-related late-onset scapuloperoneal muscular dystrophy	ENSEMBL:ENSG00000092054	myosin heavy chain 7
+ORPHANET:438178	Fatty acyl-CoA reductase 1 deficiency	ENSEMBL:ENSG00000197601	fatty acyl-CoA reductase 1
+ORPHANET:438159	STAT3-related early-onset multisystem autoimmune disease	ENSEMBL:ENSG00000168610	signal transducer and activator of transcription 3
+ORPHANET:438134	PCNA-related progressive neurodegenerative photosensitivity syndrome	ENSEMBL:ENSG00000132646	proliferating cell nuclear antigen
+ORPHANET:438117	Steel syndrome	ENSEMBL:ENSG00000196739	collagen type XXVII alpha 1 chain
+ORPHANET:438114	RARS-related autosomal recessive hypomyelinating leukodystrophy	ENSEMBL:ENSG00000113643	arginyl-tRNA synthetase 1
+ORPHANET:438075	Ketoacidosis due to monocarboxylate transporter-1 deficiency	ENSEMBL:ENSG00000155380	solute carrier family 16 member 1
+ORPHANET:438274	GCGR-related hyperglucagonemia	ENSEMBL:ENSG00000215644	glucagon receptor
+ORPHANET:438216	PURA-related severe neonatal hypotonia-seizures-encephalopathy syndrome due to a point mutation	ENSEMBL:ENSG00000185129	purine rich element binding protein A
+ORPHANET:439212	Early-onset myopathy-areflexia-respiratory distress-dysphagia syndrome	ENSEMBL:ENSG00000145794	multiple EGF like domains 10
+ORPHANET:439218	KCNQ2-related epileptic encephalopathy	ENSEMBL:ENSG00000075043	potassium voltage-gated channel subfamily Q member 2
+ORPHANET:439822	PDE4D haploinsufficiency syndrome	ENSEMBL:ENSG00000113448	phosphodiesterase 4D
+ORPHANET:439854	Fatal congenital hypertrophic cardiomyopathy due to glycogen storage disease	ENSEMBL:ENSG00000106617	protein kinase AMP-activated non-catalytic subunit gamma 2
+ORPHANET:439897	Lethal fetal cerebrorenogenitourinary agenesis/hypoplasia syndrome	ENSEMBL:ENSG00000118193	kinesin family member 14
+ORPHANET:440402	Interstitial lung disease due to ABCA3 deficiency	ENSEMBL:ENSG00000167972	ATP binding cassette subfamily A member 3
+ORPHANET:440354	Autosomal dominant myopia-midfacial retrusion-sensorineural hearing loss-rhizomelic dysplasia syndrome	ENSEMBL:ENSG00000060718	collagen type XI alpha 1 chain
+ORPHANET:440392	Interstitial lung disease due to SP-C deficiency	ENSEMBL:ENSG00000168484	surfactant protein C
+ORPHANET:440713	Isolated sedoheptulokinase deficiency	ENSEMBL:ENSG00000197417	sedoheptulokinase
+ORPHANET:440427	Severe early-onset pulmonary alveolar proteinosis due to MARS deficiency	ENSEMBL:ENSG00000166986	methionyl-tRNA synthetase 1
+ORPHANET:440706	Ribose-5-P isomerase deficiency	ENSEMBL:ENSG00000153574	ribose 5-phosphate isomerase A
+ORPHANET:443057	Sporadic porphyria cutanea tarda	ENSEMBL:ENSG00000010704	homeostatic iron regulator
+ORPHANET:443073	Charcot-Marie-Tooth disease type 2S	ENSEMBL:ENSG00000132740	immunoglobulin mu DNA binding protein 2
+ORPHANET:443197	X-linked erythropoietic protoporphyria	ENSEMBL:ENSG00000158578	5'-aminolevulinate synthase 2
+ORPHANET:443236	Postural orthostatic tachycardia syndrome due to NET deficiency	ENSEMBL:ENSG00000103546	solute carrier family 6 member 2
+ORPHANET:277	Severe combined immunodeficiency due to adenosine deaminase deficiency	ENSEMBL:ENSG00000196839	adenosine deaminase
+ORPHANET:443162	NDE1-related microhydranencephaly	ENSEMBL:ENSG00000072864	nudE neurodevelopment protein 1
+ORPHANET:443811	PGM3-CDG	ENSEMBL:ENSG00000013375	phosphoglucomutase 3
+ORPHANET:443950	DNAJB2-related Charcot-Marie-Tooth disease type 2	ENSEMBL:ENSG00000135924	DnaJ heat shock protein family (Hsp40) member B2
+ORPHANET:443988	Ventriculomegaly-cystic kidney disease	ENSEMBL:ENSG00000148204	crumbs cell polarity complex component 2
+ORPHANET:444092	Autoimmune interstitial lung disease-arthritis syndrome	ENSEMBL:ENSG00000122218	COPI coat complex subunit alpha
+ORPHANET:444099	Autosomal dominant spastic paraplegia type 73	ENSEMBL:ENSG00000169169	carnitine palmitoyltransferase 1C
+ORPHANET:444138	Peeling skin-leukonychia-acral punctate keratoses-cheilitis-knuckle pads syndrome	ENSEMBL:ENSG00000153113	calpastatin
+ORPHANET:443995	Mandibulofacial dysostosis with alopecia	ENSEMBL:ENSG00000151617	endothelin receptor type A
+ORPHANET:444048	46,XX ovarian dysgenesis-short stature syndrome	ENSEMBL:ENSG00000111877	minichromosome maintenance 9 homologous recombination repair factor
+ORPHANET:444013	Combined oxidative phosphorylation defect type 23	ENSEMBL:ENSG00000130299	GTP binding protein 3, mitochondrial
+ORPHANET:444069	Lethal fetal brain malformation-duodenal atresia-bilateral renal hypoplasia syndrome	ENSEMBL:ENSG00000117724	centromere protein F
+ORPHANET:444077	Cognitive impairment-coarse facies-heart defects-obesity-pulmonary involvement-short stature-skeletal dysplasia syndrome	ENSEMBL:ENSG00000072364	ALF transcription elongation factor 4
+ORPHANET:444072	Cerebellar-facial-dental syndrome	ENSEMBL:ENSG00000185024	BRF1 RNA polymerase III transcription initiation factor subunit
+ORPHANET:444463	Autoimmune hemolytic anemia-autoimmune thrombocytopenia-primary immunodeficiency syndrome	ENSEMBL:ENSG00000134900	tripeptidyl peptidase 2
+ORPHANET:444458	Combined oxidative phosphorylation defect type 24	ENSEMBL:ENSG00000137513	asparaginyl-tRNA synthetase 2, mitochondrial
+ORPHANET:445110	Limb-girdle muscular dystrophy due to POMK deficiency	ENSEMBL:ENSG00000185900	protein O-mannose kinase
+ORPHANET:445062	Juvenile-onset diabetes mellitus-central and peripheral neurodegeneration syndrome	ENSEMBL:ENSG00000102580	DnaJ heat shock protein family (Hsp40) member C3
+ORPHANET:445038	3-methylglutaconic aciduria type 7	ENSEMBL:ENSG00000162129	caseinolytic mitochondrial matrix peptidase chaperone subunit B
+ORPHANET:445018	Combined immunodeficiency due to LRBA deficiency	ENSEMBL:ENSG00000198589	LPS responsive beige-like anchor protein
+ORPHANET:447731	NIK deficiency	ENSEMBL:ENSG00000006062	mitogen-activated protein kinase kinase kinase 14
+ORPHANET:447737	DOCK2 deficiency	ENSEMBL:ENSG00000134516	dedicator of cytokinesis 2
+ORPHANET:447740	Susceptibility to localized juvenile periodontitis	ENSEMBL:ENSG00000171051	formyl peptide receptor 1
+ORPHANET:447896	Tremor-ataxia-central hypomyelination syndrome	ENSEMBL:ENSG00000148606	RNA polymerase III subunit A
+ORPHANET:447893	Hypomyelination-cerebellar atrophy-hypoplasia of the corpus callosum syndrome	ENSEMBL:ENSG00000148606	RNA polymerase III subunit A
+ORPHANET:447795	Lipoyl transferase 2 deficiency	ENSEMBL:ENSG00000175536	lipoyl(octanoyl) transferase 2
+ORPHANET:447784	Mitochondrial pyruvate carrier deficiency	ENSEMBL:ENSG00000060762	mitochondrial pyruvate carrier 1
+ORPHANET:447757	Autosomal dominant spastic paraplegia type 9B	ENSEMBL:ENSG00000059573	aldehyde dehydrogenase 18 family member A1
+ORPHANET:447760	Autosomal recessive spastic paraplegia type 9B	ENSEMBL:ENSG00000059573	aldehyde dehydrogenase 18 family member A1
+ORPHANET:412066	PRKAR1B-related neurodegenerative dementia with intermediate filaments	ENSEMBL:ENSG00000188191	protein kinase cAMP-dependent type I regulatory subunit beta
+ORPHANET:412057	Autosomal recessive cerebellar ataxia due to STUB1 deficiency	ENSEMBL:ENSG00000103266	STIP1 homology and U-box containing protein 1
+ORPHANET:412181	Epidermolysis bullosa simplex due to BP230 deficiency	ENSEMBL:ENSG00000151914	dystonin
+ORPHANET:412069	AHDC1-related intellectual disability-obstructive sleep apnea-mild dysmorphism syndrome	ENSEMBL:ENSG00000126705	AT-hook DNA binding motif containing 1
+ORPHANET:412189	Epidermolysis bullosa simplex due to exophilin 5 deficiency	ENSEMBL:ENSG00000110723	exophilin 5
+ORPHANET:412206	Primary failure of tooth eruption	ENSEMBL:ENSG00000160801	parathyroid hormone 1 receptor
+ORPHANET:420179	Malan overgrowth syndrome	ENSEMBL:ENSG00000008441	nuclear factor I X
+ORPHANET:420702	Autosomal recessive severe congenital neutropenia due to CSF3R deficiency	ENSEMBL:ENSG00000119535	colony stimulating factor 3 receptor
+ORPHANET:420728	Combined oxidative phosphorylation defect type 20	ENSEMBL:ENSG00000204394	valyl-tRNA synthetase 1
+ORPHANET:420733	Combined oxidative phosphorylation defect type 21	ENSEMBL:ENSG00000143374	threonyl-tRNA synthetase 2, mitochondrial
+ORPHANET:420741	RIDDLE syndrome	ENSEMBL:ENSG00000163961	ring finger protein 168
+ORPHANET:420492	Adult-onset cervical dystonia, DYT23 type	ENSEMBL:ENSG00000148337	CDKN1A interacting zinc finger protein 1
+ORPHANET:420485	Cranio-cervical dystonia with laryngeal and upper-limb involvement	ENSEMBL:ENSG00000134343	anoctamin 3
+ORPHANET:420429	Glycogen storage disease due to acid maltase deficiency, late-onset	ENSEMBL:ENSG00000171298	alpha glucosidase
+ORPHANET:420611	Transient myeloproliferative syndrome	ENSEMBL:ENSG00000102145	GATA binding protein 1
+ORPHANET:420584	Postaxial polydactyly-anterior pituitary anomalies-facial dysmorphism syndrome	ENSEMBL:ENSG00000074047	GLI family zinc finger 2
+ORPHANET:420699	Autosomal recessive severe congenital neutropenia due to CXCR2 deficiency	ENSEMBL:ENSG00000180871	C-X-C motif chemokine receptor 2
+ORPHANET:420686	Woolly hair-palmoplantar keratoderma syndrome	ENSEMBL:ENSG00000197256	KN motif and ankyrin repeat domains 2
+ORPHANET:420561	Temple-Baraitser syndrome	ENSEMBL:ENSG00000143473	potassium voltage-gated channel subfamily H member 1
+ORPHANET:420573	Severe combined immunodeficiency due to CTPS1 deficiency	ENSEMBL:ENSG00000171793	CTP synthase 1
+ORPHANET:420566	Bleeding disorder due to CalDAG-GEFI deficiency	ENSEMBL:ENSG00000068831	RAS guanyl releasing protein 2
+ORPHANET:423461	Mucolipidosis type III alpha/beta	ENSEMBL:ENSG00000111670	N-acetylglucosamine-1-phosphate transferase subunits alpha and beta
+ORPHANET:423470	Mucolipidosis type III gamma	ENSEMBL:ENSG00000090581	N-acetylglucosamine-1-phosphate transferase subunit gamma
+ORPHANET:423454	Nail and teeth abnormalities-marginal palmoplantar keratoderma-oral hyperpigmentation syndrome	ENSEMBL:ENSG00000083307	grainyhead like transcription factor 2
+ORPHANET:423384	Autosomal recessive severe congenital neutropenia due to JAGN1 deficiency	ENSEMBL:ENSG00000171135	jagunal homolog 1
+ORPHANET:423296	Spinocerebellar ataxia type 38	ENSEMBL:ENSG00000012660	ELOVL fatty acid elongase 5
+ORPHANET:423306	Microcephaly-short stature-intellectual disability-facial dysmorphism syndrome	ENSEMBL:ENSG00000172053	glutaminyl-tRNA synthetase 1
+ORPHANET:423479	X-linked intellectual disability-limb spasticity-retinal dystrophy-diabetes insipidus syndrome	ENSEMBL:ENSG00000147224	phosphoribosyl pyrophosphate synthetase 1
+ORPHANET:423275	Spinocerebellar ataxia type 40	ENSEMBL:ENSG00000015133	coiled-coil domain containing 88C
+ORPHANET:424107	Congenital myopathy with myasthenic-like onset	ENSEMBL:ENSG00000196218	ryanodine receptor 1
+ORPHANET:424099	Colobomatous microphthalmia-rhizomelic dysplasia syndrome	ENSEMBL:ENSG00000181541	mab-21 like 2
+ORPHANET:424261	TOR1AIP1-related limb-girdle muscular dystrophy	ENSEMBL:ENSG00000143337	torsin 1A interacting protein 1
+ORPHANET:424027	Progressive myoclonic epilepsy type 8	ENSEMBL:ENSG00000223802	ceramide synthase 1
+ORPHANET:423894	Microcephaly-complex motor and sensory axonal neuropathy syndrome	ENSEMBL:ENSG00000100749	VRK serine/threonine kinase 1
+ORPHANET:425120	STING-associated vasculopathy with onset in infancy	ENSEMBL:ENSG00000184584	stimulator of interferon response cGAMP interactor 1
+ORPHANET:431361	Progressive encephalopathy with leukodystrophy due to DECR deficiency	ENSEMBL:ENSG00000152620	NAD kinase 2, mitochondrial
+ORPHANET:431272	X-linked scapuloperoneal muscular dystrophy	ENSEMBL:ENSG00000022267	four and a half LIM domains 1
+ORPHANET:431329	Autosomal recessive spastic paraplegia type 57	ENSEMBL:ENSG00000114354	trafficking from ER to golgi regulator
+ORPHANET:431255	Scapuloperoneal spinal muscular atrophy	ENSEMBL:ENSG00000111199	transient receptor potential cation channel subfamily V member 4
+ORPHANET:431149	Combined immunodeficiency due to OX40 deficiency	ENSEMBL:ENSG00000186827	TNF receptor superfamily member 4
+ORPHANET:435438	Progressive myoclonic epilepsy type 7	ENSEMBL:ENSG00000129159	potassium voltage-gated channel subfamily C member 1
+ORPHANET:435387	Autosomal dominant Charcot-Marie-Tooth disease type 2Y	ENSEMBL:ENSG00000165280	valosin containing protein
+ORPHANET:434179	Orofaciodigital syndrome type 14	ENSEMBL:ENSG00000168014	C2 domain containing 3 centriole elongation regulator
+ORPHANET:504476	Cerebellar ataxia with neuropathy and bilateral vestibular areflexia syndrome	ENSEMBL:ENSG00000035928	replication factor C subunit 1
+ORPHANET:504523	Severe combined immunodeficiency due to LAT deficiency	ENSEMBL:ENSG00000213658	linker for activation of T cells
+ORPHANET:504530	Combined immunodeficiency due to Moesin deficiency	ENSEMBL:ENSG00000147065	moesin
+ORPHANET:26793	Very long chain acyl-CoA dehydrogenase deficiency	ENSEMBL:ENSG00000072778	acyl-CoA dehydrogenase very long chain
+ORPHANET:28378	Tyrosinemia type 2	ENSEMBL:ENSG00000198650	tyrosine aminotransferase
+ORPHANET:29073	Multiple myeloma	ENSEMBL:ENSG00000110092	cyclin D1
+ORPHANET:320	Apparent mineralocorticoid excess	ENSEMBL:ENSG00000176387	hydroxysteroid 11-beta dehydrogenase 2
+ORPHANET:230	Dopamine beta-hydroxylase deficiency	ENSEMBL:ENSG00000123454	dopamine beta-hydroxylase
+ORPHANET:404	Familial hyperaldosteronism type II	ENSEMBL:ENSG00000114859	chloride voltage-gated channel 2
+ORPHANET:162	Cataract-glaucoma syndrome	ENSEMBL:ENSG00000107859	paired like homeodomain 3
+ORPHANET:25980	X-linked myopathy with excessive autophagy	ENSEMBL:ENSG00000160131	vacuolar ATPase assembly factor VMA21
+ORPHANET:26792	Short chain acyl-CoA dehydrogenase deficiency	ENSEMBL:ENSG00000122971	acyl-CoA dehydrogenase short chain
+ORPHANET:266	Autosomal dominant limb-girdle muscular dystrophy type 1A	ENSEMBL:ENSG00000120729	myotilin
+ORPHANET:353	Gamma-sarcoglycan-related limb-girdle muscular dystrophy R5	ENSEMBL:ENSG00000102683	sarcoglycan gamma
+ORPHANET:219	Delta-sarcoglycan-related limb-girdle muscular dystrophy R6	ENSEMBL:ENSG00000170624	sarcoglycan delta
+ORPHANET:119	Beta-sarcoglycan-related limb-girdle muscular dystrophy R4	ENSEMBL:ENSG00000163069	sarcoglycan beta
+ORPHANET:505227	Combined immunodeficiency due to GINS1 deficiency	ENSEMBL:ENSG00000101003	GINS complex subunit 1
+ORPHANET:505237	Early-onset seizures-distal limb anomalies-facial dysmorphism-global developmental delay syndrome	ENSEMBL:ENSG00000155100	OTU deubiquitinase 6B
+ORPHANET:505216	3-methylglutaconic aciduria type 9	ENSEMBL:ENSG00000105197	translocase of inner mitochondrial membrane 50
+ORPHANET:272	Congenital muscular dystrophy, Fukuyama type	ENSEMBL:ENSG00000106692	fukutin
+ORPHANET:505208	3-methylglutaconic aciduria type 8	ENSEMBL:ENSG00000115317	HtrA serine peptidase 2
+ORPHANET:268	Dysferlin-related limb-girdle muscular dystrophy R2	ENSEMBL:ENSG00000135636	dysferlin
+ORPHANET:600	Vocal cord and pharyngeal distal myopathy	ENSEMBL:ENSG00000015479	matrin 3
+ORPHANET:505248	Mucopolysaccharidosis-like syndrome with congenital heart defects and hematopoietic disorders	ENSEMBL:ENSG00000139719	VPS33A core subunit of CORVET and HOPS complexes
+ORPHANET:609	Tibial muscular dystrophy	ENSEMBL:ENSG00000155657	titin
+ORPHANET:602	GNE myopathy	ENSEMBL:ENSG00000159921	glucosamine (UDP-N-acetyl)-2-epimerase/N-acetylmannosamine kinase
+ORPHANET:505242	Psychomotor regression-oculomotor apraxia-movement disorder-nephropathy syndrome	ENSEMBL:ENSG00000014824	solute carrier family 30 member 9
+ORPHANET:508093	MEPAN syndrome	ENSEMBL:ENSG00000116353	mitochondrial trans-2-enoyl-CoA reductase
+ORPHANET:508533	Skeletal dysplasia-T-cell immunodeficiency-developmental delay syndrome	ENSEMBL:ENSG00000012232	exostosin like glycosyltransferase 3
+ORPHANET:508542	Congenital progressive bone marrow failure-B-cell immunodeficiency-skeletal dysplasia syndrome	ENSEMBL:ENSG00000162601	Myb like, SWIRM and MPN domains 1
+ORPHANET:508529	Intermediate epidermolysis bullosa simplex with cardiomyopathy	ENSEMBL:ENSG00000114796	kelch like family member 24
+ORPHANET:508523	Hyperphenylalaninemia due to DNAJC12 deficiency	ENSEMBL:ENSG00000108176	DnaJ heat shock protein family (Hsp40) member C12
+ORPHANET:508488	8q24.3 microdeletion syndrome	ENSEMBL:ENSG00000179950	poly(U) binding splicing factor 60
+ORPHANET:508476	Cleft lip and palate-craniofacial dysmorphism-congenital heart defect-hearing loss syndrome	ENSEMBL:ENSG00000068001	hyaluronidase 2
+ORPHANET:508501	Oral-facial-digital syndrome with short stature and brachymesophalangy	ENSEMBL:ENSG00000114446	intraflagellar transport 57
+ORPHANET:508498	Intellectual disability-cardiac anomalies-short stature-joint laxity syndrome	ENSEMBL:ENSG00000179950	poly(U) binding splicing factor 60
+ORPHANET:505652	CDKL5-deficiency disorder	ENSEMBL:ENSG00000008086	cyclin dependent kinase like 5
+ORPHANET:506334	Familial steroid-resistant nephrotic syndrome with adrenal insufficiency	ENSEMBL:ENSG00000166224	sphingosine-1-phosphate lyase 1
+ORPHANET:506307	Stromme syndrome	ENSEMBL:ENSG00000117724	centromere protein F
+ORPHANET:506358	Gabriele-de Vries syndrome	ENSEMBL:ENSG00000100811	YY1 transcription factor
+ORPHANET:506353	Autosomal recessive complex spastic paraplegia due to Kennedy pathway dysfunction	ENSEMBL:ENSG00000138018	selenoprotein I
+ORPHANET:495274	Charcot-Marie-Tooth disease type 2T	ENSEMBL:ENSG00000196549	membrane metalloendopeptidase
+ORPHANET:495844	C11ORF73-related autosomal recessive hypomyelinating leukodystrophy	ENSEMBL:ENSG00000149196	heat shock protein nuclear import factor hikeshi
+ORPHANET:496641	Early-onset progressive diffuse brain atrophy-microcephaly-muscle weakness-optic atrophy syndrome	ENSEMBL:ENSG00000141556	tubulin folding cofactor D
+ORPHANET:496686	Kyphosis-lateral tongue atrophy-myofibrillar myopathy syndrome	ENSEMBL:ENSG00000174611	kyphoscoliosis peptidase
+ORPHANET:496689	Kyphoscoliosis-lateral tongue atrophy-hereditary spastic paraplegia syndrome	ENSEMBL:ENSG00000174611	kyphoscoliosis peptidase
+ORPHANET:496751	EVEN-plus syndrome	ENSEMBL:ENSG00000113013	heat shock protein family A (Hsp70) member 9
+ORPHANET:496756	Early-onset progressive encephalopathy-spastic ataxia-distal spinal muscular atrophy syndrome	ENSEMBL:ENSG00000284770	tubulin folding cofactor E
+ORPHANET:496790	Ocular anomalies-axonal neuropathy-developmental delay syndrome	ENSEMBL:ENSG00000197785	ATPase family AAA domain containing 3A
+ORPHANET:494433	MIRAGE syndrome	ENSEMBL:ENSG00000205413	sterile alpha motif domain containing 9
+ORPHANET:494439	Retinitis pigmentosa-hearing loss-premature aging-short stature-facial dysmorphism syndrome	ENSEMBL:ENSG00000130713	exosome component 2
+ORPHANET:494444	DIAPH1-related sensorineural hearing loss-thrombocytopenia syndrome	ENSEMBL:ENSG00000131504	diaphanous related formin 1
+ORPHANET:494344	RERE-related neurodevelopmental syndrome	ENSEMBL:ENSG00000142599	arginine-glutamic acid dipeptide repeats
+ORPHANET:494541	Childhood-onset benign chorea with striatal involvement	ENSEMBL:ENSG00000112541	phosphodiesterase 10A
+ORPHANET:494526	Infantile-onset generalized dyskinesia with orofacial involvement	ENSEMBL:ENSG00000112541	phosphodiesterase 10A
+ORPHANET:500180	Childhood-onset motor and cognitive regression syndrome with extrapyramidal movement disorder	ENSEMBL:ENSG00000108312	upstream binding transcription factor
+ORPHANET:500188	X-linked external auditory canal atresia-dilated internal auditory canal-facial dysmorphism syndrome	ENSEMBL:ENSG00000158301	G protein-coupled receptor associated sorting protein 2
+ORPHANET:500150	Brain malformations-musculoskeletal abnormalities-facial dysmorphism-intellectual disability syndrome	ENSEMBL:ENSG00000159140	SON DNA and RNA binding protein
+ORPHANET:500159	Microcephaly-corpus callosum and cerebellar vermis hypoplasia-facial dysmorphism-intellectual disability syndrom	ENSEMBL:ENSG00000136238	Rac family small GTPase 1
+ORPHANET:500135	Multinucleated neurons-anhydramnios-renal dysplasia-cerebellar hypoplasia-hydranencephaly syndrome	ENSEMBL:ENSG00000138180	centrosomal protein 55
+ORPHANET:500144	Early-onset progressive encephalopathy-hearing loss-pons hypoplasia-brain atrophy syndrome	ENSEMBL:ENSG00000171853	trafficking protein particle complex subunit 12
+ORPHANET:500055	16p13.2 microdeletion syndrome	ENSEMBL:ENSG00000187555	ubiquitin specific peptidase 7
+ORPHANET:500095	Tall stature-intellectual disability-renal anomalies syndrome	ENSEMBL:ENSG00000172500	FGF1 intracellular binding protein
+ORPHANET:500062	Infantile-onset periodic fever-panniculitis-dermatosis syndrome	ENSEMBL:ENSG00000154124	OTU deubiquitinase with linear linkage specificity
+ORPHANET:123	Björnstad syndrome	ENSEMBL:ENSG00000074582	BCS1 homolog, ubiquinol-cytochrome c reductase complex chaperone
+ORPHANET:898	Wagner disease	ENSEMBL:ENSG00000038427	versican
+ORPHANET:505	Graham Little-Piccardi-Lassueur syndrome	ENSEMBL:ENSG00000204287	major histocompatibility complex, class II, DR alpha
+ORPHANET:500548	Osteosclerotic metaphyseal dysplasia	ENSEMBL:ENSG00000154237	leucine rich repeat kinase 1
+ORPHANET:500533	Polyhydramnios-megalencephaly-symptomatic epilepsy syndrome	ENSEMBL:ENSG00000266173	STE20 related adaptor alpha
+ORPHANET:500545	Severe neurodevelopmental disorder with feeding difficulties-stereotypic hand movement-bilateral cataract	ENSEMBL:ENSG00000160877	nucleus accumbens associated 1
+ORPHANET:502423	Mitochondrial myopathy-cerebellar ataxia-pigmentary retinopathy syndrome	ENSEMBL:ENSG00000125459	misato mitochondrial distribution and morphology regulator 1
+ORPHANET:502430	Metopic ridging-ptosis-facial dysmorphism syndrome	ENSEMBL:ENSG00000148143	zinc finger protein 462
+ORPHANET:502434	STAG1-related intellectual disability-facial dysmorphism-gastroesophageal reflux syndrome	ENSEMBL:ENSG00000118007	stromal antigen 1
+ORPHANET:502444	Alkaline ceramidase 3 deficiency	ENSEMBL:ENSG00000078124	alkaline ceramidase 3
+ORPHANET:91	Aromatase deficiency	ENSEMBL:ENSG00000137869	cytochrome P450 family 19 subfamily A member 1
+ORPHANET:785	Estrogen resistance syndrome	ENSEMBL:ENSG00000091831	estrogen receptor 1
+ORPHANET:841	Sebocystomatosis	ENSEMBL:ENSG00000128422	keratin 17
+ORPHANET:867	Familial multiple trichoepithelioma	ENSEMBL:ENSG00000083799	CYLD lysine 63 deubiquitinase
+ORPHANET:497906	Childhood-onset basal ganglia degeneration syndrome	ENSEMBL:ENSG00000103043	VAC14 component of PIKFYVE complex
+ORPHANET:523	Hereditary leiomyomatosis and renal cell cancer	ENSEMBL:ENSG00000091483	fumarate hydratase
+ORPHANET:497757	MME-related autosomal dominant Charcot Marie Tooth disease type 2	ENSEMBL:ENSG00000196549	membrane metalloendopeptidase
+ORPHANET:497764	Spinocerebellar ataxia type 43	ENSEMBL:ENSG00000196549	membrane metalloendopeptidase
+ORPHANET:530	Lipoid proteinosis	ENSEMBL:ENSG00000143369	extracellular matrix protein 1
+ORPHANET:462	NON RARE IN EUROPE: Autosomal dominant ichthyosis vulgaris	ENSEMBL:ENSG00000143631	filaggrin
+ORPHANET:734	Alpha delta granule deficiency	ENSEMBL:ENSG00000165702	growth factor independent 1B transcriptional repressor
+ORPHANET:721	Gray platelet syndrome	ENSEMBL:ENSG00000160796	neurobeachin like 2
+ORPHANET:722	Hypoplasminogenemia	ENSEMBL:ENSG00000122194	plasminogen
+ORPHANET:749	Congenital prekallikrein deficiency	ENSEMBL:ENSG00000164344	kallikrein B1
+ORPHANET:483	Congenital high-molecular-weight kininogen deficiency	ENSEMBL:ENSG00000113889	kininogen 1
+ORPHANET:498359	Aquagenic palmoplantar keratoderma	ENSEMBL:ENSG00000001626	CF transmembrane conductance regulator
+ORPHANET:852	X-linked thrombocytopenia with normal platelets	ENSEMBL:ENSG00000015285	WASP actin nucleation promoting factor
+ORPHANET:465	Congenital plasminogen activator inhibitor type 1 deficiency	ENSEMBL:ENSG00000106366	serpin family E member 1
+ORPHANET:498251	Menstrual cycle-dependent periodic fever	ENSEMBL:ENSG00000178394	5-hydroxytryptamine receptor 1A
+ORPHANET:143	Parathyroid carcinoma	ENSEMBL:ENSG00000134371	cell division cycle 73
+ORPHANET:786	Generalized glucocorticoid resistance syndrome	ENSEMBL:ENSG00000113580	nuclear receptor subfamily 3 group C member 1
+ORPHANET:615	Familial atrial myxoma	ENSEMBL:ENSG00000108946	protein kinase cAMP-dependent type I regulatory subunit alpha
+ORPHANET:498497	Short rib-polydactyly syndrome type 5	ENSEMBL:ENSG00000118965	WD repeat domain 35
+ORPHANET:498693	MYBPC1-related autosomal recessive non-lethal arthrogryposis multiplex congenita syndrome	ENSEMBL:ENSG00000196091	myosin binding protein C1
+ORPHANET:840	Syringocystadenoma papilliferum	ENSEMBL:ENSG00000157764	B-Raf proto-oncogene, serine/threonine kinase
+ORPHANET:498494	Mirror-image polydactyly	ENSEMBL:ENSG00000069011	paired like homeodomain 1
+ORPHANET:384	Huriez syndrome	ENSEMBL:ENSG00000163104	SWI/SNF-related, matrix-associated actin-dependent regulator of chromatin, subfamily a, containing DEAD/H box 1
+ORPHANET:41	Dyschromatosis symmetrica hereditaria	ENSEMBL:ENSG00000160710	adenosine deaminase RNA specific
+ORPHANET:122	Birt-Hogg-Dubé syndrome	ENSEMBL:ENSG00000154803	folliculin
+ORPHANET:241	Dyschromatosis universalis hereditaria	ENSEMBL:ENSG00000115657	ATP binding cassette subfamily B member 6 (Langereis blood group)
+ORPHANET:211	Familial cylindromatosis	ENSEMBL:ENSG00000083799	CYLD lysine 63 deubiquitinase
+ORPHANET:2908	Kindler epidermolysis bullosa	ENSEMBL:ENSG00000101311	FERM domain containing kindlin 1
+ORPHANET:779	Reynolds syndrome	ENSEMBL:ENSG00000143815	lamin B receptor
+ORPHANET:486815	Congenital muscular dystrophy-respiratory failure-skin abnormalities-joint hyperlaxity syndrome	ENSEMBL:ENSG00000103671	thyroid hormone receptor interactor 4
+ORPHANET:485418	EMILIN-1-related connective tissue disease	ENSEMBL:ENSG00000138080	elastin microfibril interfacer 1
+ORPHANET:485421	MFF-related encephalopathy due to mitochondrial and peroxisomal fission defect	ENSEMBL:ENSG00000168958	mitochondrial fission factor
+ORPHANET:485350	CLCN4-related X-linked intellectual disability syndrome	ENSEMBL:ENSG00000073464	chloride voltage-gated channel 4
+ORPHANET:482606	X-linked keloid scarring-reduced joint mobility-increased optic cup-to-disc ratio syndrome	ENSEMBL:ENSG00000196924	filamin A
+ORPHANET:482601	Adenylosuccinate synthetase-like 1-related distal myopathy	ENSEMBL:ENSG00000185100	adenylosuccinate synthase 1
+ORPHANET:480864	Recurrent metabolic encephalomyopathic crises-rhabdomyolysis-cardiac arrhythmia-intellectual disability syndrome	ENSEMBL:ENSG00000183597	transport and golgi organization 2 homolog
+ORPHANET:480907	X-linked intellectual disability-global development delay-facial dysmorphism-sacral caudal remnant syndrome	ENSEMBL:ENSG00000147133	TATA-box binding protein associated factor 1
+ORPHANET:480898	Global developmental delay-visual anomalies-progressive cerebellar atrophy-truncal hypotonia syndrome	ENSEMBL:ENSG00000127463	ER membrane protein complex subunit 1
+ORPHANET:480880	X-linked female restricted facial dysmorphism-short stature-choanal atresia-intellectual disability	ENSEMBL:ENSG00000124486	ubiquitin specific peptidase 9 X-linked
+ORPHANET:31740	Hypersensitivity pneumonitis	ENSEMBL:ENSG00000117983	mucin 5B, oligomeric mucus/gel-forming
+ORPHANET:480556	Isolated neonatal sclerosing cholangitis	ENSEMBL:ENSG00000146038	doublecortin domain containing 2
+ORPHANET:480851	Hereditary thrombocytopenia with early-onset myelofibrosis	ENSEMBL:ENSG00000197122	SRC proto-oncogene, non-receptor tyrosine kinase
+ORPHANET:480682	POGLUT1-related limb-girdle muscular dystrophy R21	ENSEMBL:ENSG00000163389	protein O-glucosyltransferase 1
+ORPHANET:481665	USP18 deficiency	ENSEMBL:ENSG00000184979	ubiquitin specific peptidase 18
+ORPHANET:482077	HTRA1-related autosomal dominant cerebral small vessel disease	ENSEMBL:ENSG00000166033	HtrA serine peptidase 1
+ORPHANET:481986	Familial schizencephaly	ENSEMBL:ENSG00000187498	collagen type IV alpha 1 chain
+ORPHANET:481152	PYCR2-related microcephaly-progressive leukoencephalopathy	ENSEMBL:ENSG00000143811	pyrroline-5-carboxylate reductase 2
+ORPHANET:480476	Progressive familial intrahepatic cholestasis type 5	ENSEMBL:ENSG00000012504	nuclear receptor subfamily 1 group H member 4
+ORPHANET:480491	MYO5B-related progressive familial intrahepatic cholestasis	ENSEMBL:ENSG00000167306	myosin VB
+ORPHANET:480483	Progressive familial intrahepatic cholestasis type 4	ENSEMBL:ENSG00000119139	tight junction protein 2
+ORPHANET:480528	Lethal hydranencephaly-diaphragmatic hernia syndrome	ENSEMBL:ENSG00000104368	plasminogen activator, tissue type
+ORPHANET:480536	MSH3-related attenuated familial adenomatous polyposis	ENSEMBL:ENSG00000113318	mutS homolog 3
+ORPHANET:477814	Progressive microcephaly-seizures-cortical blindness-developmental delay syndrome	ENSEMBL:ENSG00000131504	diaphanous related formin 1
+ORPHANET:477787	Cytosolic phospholipase-A2 alpha deficiency associated bleeding disorder	ENSEMBL:ENSG00000116711	phospholipase A2 group IVA
+ORPHANET:478029	Combined oxidative phosphorylation defect type 29	ENSEMBL:ENSG00000100348	thioredoxin 2
+ORPHANET:478042	Combined oxidative phosphorylation defect type 30	ENSEMBL:ENSG00000174173	tRNA methyltransferase 10C, mitochondrial RNase P subunit
+ORPHANET:477993	Palatal anomalies-widely spaced teeth-facial dysmorphism-developmental delay syndrome	ENSEMBL:ENSG00000004487	lysine demethylase 1A
+ORPHANET:477857	Autosomal recessive mendelian susceptibility to mycobacterial diseases due to complete RORgamma receptor deficiency	ENSEMBL:ENSG00000143365	RAR related orphan receptor C
+ORPHANET:477817	PMP22-RAI1 contiguous gene duplication syndrome	ENSEMBL:ENSG00000108557	retinoic acid induced 1
+ORPHANET:477831	Kosaki overgrowth syndrome	ENSEMBL:ENSG00000113721	platelet derived growth factor receptor beta
+ORPHANET:478049	Lethal left ventricular non-compaction-seizures-hypotonia-cataract-developmental delay syndrome	ENSEMBL:ENSG00000027001	mitochondrial intermediate peptidase
+ORPHANET:478664	Hereditary sensory and autonomic neuropathy type 8	ENSEMBL:ENSG00000130711	PR/SET domain 12
+ORPHANET:477661	IL21-related infantile inflammatory bowel disease	ENSEMBL:ENSG00000138684	interleukin 21
+ORPHANET:477684	Combined oxidative phosphorylation defect type 26	ENSEMBL:ENSG00000126814	tRNA methyltransferase 5
+ORPHANET:477673	Postnatal microcephaly-infantile hypotonia-spastic diplegia-dysarthria-intellectual disability syndrome	ENSEMBL:ENSG00000166123	glutamic--pyruvic transaminase 2
+ORPHANET:477749	Pontine autosomal dominant microangiopathy with leukoencephalopathy	ENSEMBL:ENSG00000187498	collagen type IV alpha 1 chain
+ORPHANET:477774	Combined oxidative phosphorylation defect type 27	ENSEMBL:ENSG00000134905	cysteinyl-tRNA synthetase 2, mitochondrial
+ORPHANET:476119	Autosomal dominant preaxial polydactyly-upperback hypertrichosis syndrome	ENSEMBL:ENSG00000164690	sonic hedgehog signaling molecule
+ORPHANET:476113	Combined immunodeficiency due to TFRC deficiency	ENSEMBL:ENSG00000072274	transferrin receptor
+ORPHANET:476126	Micrognathia-recurrent infections-behavioral abnormalities-mild intellectual disability syndrome	ENSEMBL:ENSG00000038382	trio Rho guanine nucleotide exchange factor
+ORPHANET:476406	Congenital generalized hypercontractile muscle stiffness syndrome	ENSEMBL:ENSG00000143549	tropomyosin 3
+ORPHANET:476394	PMP2-related Charcot-Marie-Tooth disease type 1	ENSEMBL:ENSG00000147588	peripheral myelin protein 2
+ORPHANET:493342	Vibratory urticaria	ENSEMBL:ENSG00000127507	adhesion G protein-coupled receptor E2
+ORPHANET:488642	TELO2-related intellectual disability-neurodevelopmental disorder	ENSEMBL:ENSG00000100726	telomere maintenance 2
+ORPHANET:488647	DDX41-related hematologic malignancy predisposition syndrome	ENSEMBL:ENSG00000183258	DEAD-box helicase 41
+ORPHANET:488650	Distal myopathy, Tateyama type	ENSEMBL:ENSG00000182533	caveolin 3
+ORPHANET:488618	Transketolase deficiency	ENSEMBL:ENSG00000163931	transketolase
+ORPHANET:488627	Severe growth deficiency-strabismus-extensive dermal melanocytosis-intellectual disability syndrome	ENSEMBL:ENSG00000110060	pseudouridine synthase 3
+ORPHANET:488632	TBCK-related intellectual disability syndrome	ENSEMBL:ENSG00000145348	TBC1 domain containing kinase
+ORPHANET:488635	Early-onset epilepsy-intellectual disability-brain anomalies syndrome	ENSEMBL:ENSG00000174227	phosphatidylinositol glycan anchor biosynthesis class G
+ORPHANET:488265	Osteofibrous dysplasia	ENSEMBL:ENSG00000105976	MET proto-oncogene, receptor tyrosine kinase
+ORPHANET:488232	Split-foot malformation-mesoaxial polydactyly syndrome	ENSEMBL:ENSG00000091436	mitogen-activated protein kinase kinase kinase 20
+ORPHANET:488333	Autosomal dominant Charcot-Marie-Tooth disease type 2W	ENSEMBL:ENSG00000170445	histidyl-tRNA synthetase 1
+ORPHANET:488437	SIX2-related frontonasal dysplasia	ENSEMBL:ENSG00000170577	SIX homeobox 2
+ORPHANET:488613	Global developmental delay-neuro-ophthalmological abnormalities-seizures-intellectual disability syndrome	ENSEMBL:ENSG00000078369	G protein subunit beta 1
+ORPHANET:488594	Autosomal recessive spastic paraplegia type 76	ENSEMBL:ENSG00000014216	calpain 1
+ORPHANET:488197	Familial progressive retinal dystrophy-iris coloboma-congenital cataract syndrome	ENSEMBL:ENSG00000207935	microRNA 204
+ORPHANET:488168	Microcephaly-congenital cataract-psoriasiform dermatitis syndrome	ENSEMBL:ENSG00000052802	methylsterol monooxygenase 1
+ORPHANET:487796	Macrothrombocytopenia-lymphedema-developmental delay-facial dysmorphism-camptodactyly syndrome	ENSEMBL:ENSG00000070831	cell division cycle 42
+ORPHANET:487814	Autosomal dominant Charcot-Marie-Tooth disease type 2 due to DGAT2 mutation	ENSEMBL:ENSG00000062282	diacylglycerol O-acyltransferase 2
+ORPHANET:487825	Pierpont syndrome	ENSEMBL:ENSG00000177565	TBL1X/Y related 1
+ORPHANET:31150	Tangier disease	ENSEMBL:ENSG00000165029	ATP binding cassette subfamily A member 1
+ORPHANET:31043	Primary hypomagnesemia with hypercalciuria and nephrocalcinosis without severe ocular involvement	ENSEMBL:ENSG00000113946	claudin 16
+ORPHANET:30924	Primary hypomagnesemia with secondary hypocalcemia	ENSEMBL:ENSG00000119121	transient receptor potential cation channel subfamily M member 6
+ORPHANET:30925	Hereditary central diabetes insipidus	ENSEMBL:ENSG00000101200	arginine vasopressin
+ORPHANET:476084	BVES-related limb-girdle muscular dystrophy	ENSEMBL:ENSG00000112276	blood vessel epicardial substance
+ORPHANET:476096	Erythrokeratodermia-cardiomyopathy syndrome	ENSEMBL:ENSG00000096696	desmoplakin
+ORPHANET:476093	Autosomal dominant distal axonal motor neuropathy-myofibrillar myopathy syndrome	ENSEMBL:ENSG00000152137	heat shock protein family B (small) member 8
+ORPHANET:71278	Congenital brain dysgenesis due to glutamine synthetase deficiency	ENSEMBL:ENSG00000135821	glutamate-ammonia ligase
+ORPHANET:71271	Split hand-split foot-deafness syndrome	ENSEMBL:ENSG00000105880	distal-less homeobox 5
+ORPHANET:71277	Classic glucose transporter type 1 deficiency syndrome	ENSEMBL:ENSG00000117394	solute carrier family 2 member 1
+ORPHANET:71212	Hyperinsulinism due to short chain 3-hydroxylacyl-CoA dehydrogenase deficiency	ENSEMBL:ENSG00000138796	hydroxyacyl-CoA dehydrogenase
+ORPHANET:70592	Immunodeficiency due to interleukin-1 receptor-associated kinase-4 deficiency	ENSEMBL:ENSG00000198001	interleukin 1 receptor associated kinase 4
+ORPHANET:70594	Dopa-responsive dystonia due to sepiapterin reductase deficiency	ENSEMBL:ENSG00000116096	sepiapterin reductase
+ORPHANET:70472	Congenital lactic acidosis, Saguenay-Lac-Saint-Jean type	ENSEMBL:ENSG00000138095	leucine rich pentatricopeptide repeat containing
+ORPHANET:69735	Hypotrichosis-lymphedema-telangiectasia-renal defect syndrome	ENSEMBL:ENSG00000203883	SRY-box transcription factor 18
+ORPHANET:69737	Bosley-Salih-Alorainy syndrome	ENSEMBL:ENSG00000105991	homeobox A1
+ORPHANET:69739	Athabaskan brainstem dysgenesis syndrome	ENSEMBL:ENSG00000105991	homeobox A1
+ORPHANET:69663	Low phospholipid-associated cholelithiasis	ENSEMBL:ENSG00000005471	ATP binding cassette subfamily B member 4
+ORPHANET:69723	Tyrosinemia type 3	ENSEMBL:ENSG00000158104	4-hydroxyphenylpyruvate dioxygenase
+ORPHANET:69127	NON RARE IN EUROPE: Immunoglobulin A deficiency	ENSEMBL:ENSG00000240505	TNF receptor superfamily member 13B
+ORPHANET:69126	Pyogenic arthritis-pyoderma gangrenosum-acne syndrome	ENSEMBL:ENSG00000140368	proline-serine-threonine phosphatase interacting protein 1
+ORPHANET:69087	Naegeli-Franceschetti-Jadassohn syndrome	ENSEMBL:ENSG00000186847	keratin 14
+ORPHANET:69088	Anhidrotic ectodermal dysplasia-immunodeficiency-osteopetrosis-lymphedema syndrome	ENSEMBL:ENSG00000269335	inhibitor of nuclear factor kappa B kinase regulatory subunit gamma
+ORPHANET:69085	Limb-mammary syndrome	ENSEMBL:ENSG00000073282	tumor protein p63
+ORPHANET:69076	Familial renal glucosuria	ENSEMBL:ENSG00000140675	solute carrier family 5 member 2
+ORPHANET:69063	Congenital membranous nephropathy due to fetomaternal anti-neutral endopeptidase alloimmunization	ENSEMBL:ENSG00000196549	membrane metalloendopeptidase
+ORPHANET:67046	3-methylglutaconic aciduria type 1	ENSEMBL:ENSG00000148090	AU RNA binding methylglutaconyl-CoA hydratase
+ORPHANET:67044	Thrombocytopenia with congenital dyserythropoietic anemia	ENSEMBL:ENSG00000102145	GATA binding protein 1
+ORPHANET:67045	X-linked intellectual disability with isolated growth hormone deficiency	ENSEMBL:ENSG00000134595	SRY-box transcription factor 3
+ORPHANET:67042	Late-onset retinal degeneration	ENSEMBL:ENSG00000223953	C1q and TNF related 5
+ORPHANET:67041	Hyaluronidase deficiency	ENSEMBL:ENSG00000114378	hyaluronidase 1
+ORPHANET:67036	Autosomal dominant optic atrophy and cataract	ENSEMBL:ENSG00000125741	outer mitochondrial membrane lipid metabolism regulator OPA3
+ORPHANET:66637	Diaphanospondylodysostosis	ENSEMBL:ENSG00000164619	BMP binding endothelial regulator
+ORPHANET:66634	Dilated cardiomyopathy with ataxia	ENSEMBL:ENSG00000205981	DnaJ heat shock protein family (Hsp40) member C19
+ORPHANET:66631	CEDNIK syndrome	ENSEMBL:ENSG00000099940	synaptosome associated protein 29
+ORPHANET:66629	Goldberg-Shprintzen megacolon syndrome	ENSEMBL:ENSG00000198954	kinesin family binding protein
+ORPHANET:66628	Obesity due to congenital leptin deficiency	ENSEMBL:ENSG00000174697	leptin
+ORPHANET:65282	Carvajal syndrome	ENSEMBL:ENSG00000096696	desmoplakin
+ORPHANET:65285	Lhermitte-Duclos disease	ENSEMBL:ENSG00000171862	phosphatase and tensin homolog
+ORPHANET:65284	Biotin-thiamine-responsive basal ganglia disease	ENSEMBL:ENSG00000135917	solute carrier family 19 member 3
+ORPHANET:65287	Beta-ureidopropionase deficiency	ENSEMBL:ENSG00000100024	beta-ureidopropionase 1
+ORPHANET:65288	Permanent neonatal diabetes mellitus-pancreatic and cerebellar agenesis syndrome	ENSEMBL:ENSG00000168267	pancreas associated transcription factor 1a
+ORPHANET:65748	Multiple self-healing squamous epithelioma	ENSEMBL:ENSG00000106799	transforming growth factor beta receptor 1
+ORPHANET:65743	Autosomal dominant multiple pterygium syndrome	ENSEMBL:ENSG00000109063	myosin heavy chain 3
+ORPHANET:64751	Hereditary motor and sensory neuropathy type 5	ENSEMBL:ENSG00000116688	mitofusin 2
+ORPHANET:562509	Heme oxygenase-1 deficiency	ENSEMBL:ENSG00000100292	heme oxygenase 1
+ORPHANET:64754	Nevus comedonicus syndrome	ENSEMBL:ENSG00000119638	NIMA related kinase 9
+ORPHANET:562528	Congenital limbs-face contractures-hypotonia-developmental delay syndrome	ENSEMBL:ENSG00000102452	sodium leak channel, non-selective
+ORPHANET:64755	Becker nevus syndrome	ENSEMBL:ENSG00000075624	actin beta
+ORPHANET:562559	Anterior maxillary protrusion-strabismus-intellectual disability syndrome	ENSEMBL:ENSG00000112320	sine oculis binding protein homolog
+ORPHANET:562538	Autosomal recessive extra-oral halitosis	ENSEMBL:ENSG00000143416	selenium binding protein 1
+ORPHANET:562569	TMEM94-associated congenital heart defect-facial dysmorphism-developmental delay syndrome	ENSEMBL:ENSG00000177728	transmembrane protein 94
+ORPHANET:64739	Ovarian hyperstimulation syndrome	ENSEMBL:ENSG00000170820	follicle stimulating hormone receptor
+ORPHANET:63269	Antley-Bixler syndrome with genital anomaly and disorder of steroidogenesis	ENSEMBL:ENSG00000127948	cytochrome p450 oxidoreductase
+ORPHANET:63260	Craniorachischisis	ENSEMBL:ENSG00000165617	dishevelled binding antagonist of beta catenin 1
+ORPHANET:63442	Angel-shaped phalango-epiphyseal dysplasia	ENSEMBL:ENSG00000125965	growth differentiation factor 5
+ORPHANET:63273	Distal myopathy with posterior leg and anterior hand involvement	ENSEMBL:ENSG00000128591	filamin C
+ORPHANET:63446	Acrocapitofemoral dysplasia	ENSEMBL:ENSG00000163501	Indian hedgehog signaling molecule
+ORPHANET:60040	Megalencephaly-capillary malformation-polymicrogyria syndrome	ENSEMBL:ENSG00000121879	phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunit alpha
+ORPHANET:59303	Neonatal ichthyosis-sclerosing cholangitis syndrome	ENSEMBL:ENSG00000163347	claudin 1
+ORPHANET:59306	McLeod neuroacanthocytosis syndrome	ENSEMBL:ENSG00000047597	X-linked Kx blood group antigen, Kell and VPS13A binding protein
+ORPHANET:60025	Pulmonary alveolar microlithiasis	ENSEMBL:ENSG00000157765	solute carrier family 34 member 2
+ORPHANET:564178	Primary hypomagnesemia-refractory seizures-intellectual disability syndrome	ENSEMBL:ENSG00000163399	ATPase Na+/K+ transporting subunit alpha 1
+ORPHANET:563708	Syndromic congenital sodium diarrhea	ENSEMBL:ENSG00000167642	serine peptidase inhibitor, Kunitz type 2
+ORPHANET:59181	Sorsby pseudoinflammatory fundus dystrophy	ENSEMBL:ENSG00000100234	TIMP metallopeptidase inhibitor 3
+ORPHANET:59135	Laing early-onset distal myopathy	ENSEMBL:ENSG00000092054	myosin heavy chain 7
+ORPHANET:58017	Classic hairy cell leukemia	ENSEMBL:ENSG00000157764	B-Raf proto-oncogene, serine/threonine kinase
+ORPHANET:57782	Mazabraud syndrome	ENSEMBL:ENSG00000087460	GNAS complex locus
+ORPHANET:55595	TNP03-related limb-girdle muscular dystrophy D2	ENSEMBL:ENSG00000064419	transportin 3
+ORPHANET:55596	HNRNPDL-related limb-girdle muscular dystrophy D3	ENSEMBL:ENSG00000152795	heterogeneous nuclear ribonucleoprotein D like
+ORPHANET:56304	Atelosteogenesis type II	ENSEMBL:ENSG00000155850	solute carrier family 26 member 2
+ORPHANET:56305	Atelosteogenesis type III	ENSEMBL:ENSG00000136068	filamin B
+ORPHANET:55880	Chondrosarcoma	ENSEMBL:ENSG00000182197	exostosin glycosyltransferase 1
+ORPHANET:565858	Craniosynostosis-microretrognathia-severe intellectual disability syndrome	ENSEMBL:ENSG00000138814	protein phosphatase 3 catalytic subunit alpha
+ORPHANET:565788	Infantile inflammatory bowel disease with neurological involvement	ENSEMBL:ENSG00000105329	transforming growth factor beta 1
+ORPHANET:565909	Calpain-3-related limb-girdle muscular dystrophy D4	ENSEMBL:ENSG00000092529	calpain 3
+ORPHANET:79233	Hypoxanthine guanine phosphoribosyltransferase partial deficiency	ENSEMBL:ENSG00000165704	hypoxanthine phosphoribosyltransferase 1
+ORPHANET:79237	Galactokinase deficiency	ENSEMBL:ENSG00000108479	galactokinase 1
+ORPHANET:566067	CEBPE-associated autoinflammation-immunodeficiency-neutrophil dysfunction syndrome	ENSEMBL:ENSG00000092067	CCAAT enhancer binding protein epsilon
+ORPHANET:79234	Crigler-Najjar syndrome type 1	ENSEMBL:ENSG00000241635	UDP glucuronosyltransferase family 1 member A1
+ORPHANET:79235	Crigler-Najjar syndrome type 2	ENSEMBL:ENSG00000241635	UDP glucuronosyltransferase family 1 member A1
+ORPHANET:565624	Combined oxidative phosphorylation defect type 39	ENSEMBL:ENSG00000164347	GTP dependent ribosome recycling factor mitochondrial 2
+ORPHANET:565612	Primary triglyceride deposit cardiomyovasculopathy	ENSEMBL:ENSG00000177666	patatin like phospholipase domain containing 2
+ORPHANET:79157	2-methylbutyryl-CoA dehydrogenase deficiency	ENSEMBL:ENSG00000196177	acyl-CoA dehydrogenase short/branched chain
+ORPHANET:79155	Hydroxykynureninuria	ENSEMBL:ENSG00000115919	kynureninase
+ORPHANET:79154	2-aminoadipic 2-oxoadipic aciduria	ENSEMBL:ENSG00000181192	dehydrogenase E1 and transketolase domain containing 1
+ORPHANET:79151	Acrokeratosis verruciformis of Hopf	ENSEMBL:ENSG00000174437	ATPase sarcoplasmic/endoplasmic reticulum Ca2+ transporting 2
+ORPHANET:79146	Familial progressive hyperpigmentation	ENSEMBL:ENSG00000049130	KIT ligand
+ORPHANET:79159	Isobutyryl-CoA dehydrogenase deficiency	ENSEMBL:ENSG00000151498	acyl-CoA dehydrogenase family member 8
+ORPHANET:79107	Developmental malformations-deafness-dystonia syndrome	ENSEMBL:ENSG00000075624	actin beta
+ORPHANET:566231	Resistance to thyroid hormone due to a mutation in thyroid hormone receptor alpha	ENSEMBL:ENSG00000126351	thyroid hormone receptor alpha
+ORPHANET:79106	Eiken syndrome	ENSEMBL:ENSG00000160801	parathyroid hormone 1 receptor
+ORPHANET:566243	Resistance to thyroid hormone due to a mutation in thyroid hormone receptor beta	ENSEMBL:ENSG00000151090	thyroid hormone receptor beta
+ORPHANET:79118	Neonatal diabetes-congenital hypothyroidism-congenital glaucoma-hepatic fibrosis-polycystic kidneys syndrome	ENSEMBL:ENSG00000107249	GLIS family zinc finger 3
+ORPHANET:566393	Acute mast cell leukemia	ENSEMBL:ENSG00000157404	KIT proto-oncogene, receptor tyrosine kinase
+ORPHANET:79113	Mandibulofacial dysostosis-microcephaly syndrome	ENSEMBL:ENSG00000108883	elongation factor Tu GTP binding domain containing 2
+ORPHANET:79101	Hyperprolinemia type 2	ENSEMBL:ENSG00000159423	aldehyde dehydrogenase 4 family member A1
+ORPHANET:566192	Congenital autosomal recessive small-platelet thrombocytopenia	ENSEMBL:ENSG00000082074	FYN binding protein 1
+ORPHANET:79100	Atrophoderma vermiculata	ENSEMBL:ENSG00000123384	LDL receptor related protein 1
+ORPHANET:79095	Congenital bile acid synthesis defect type 4	ENSEMBL:ENSG00000242110	alpha-methylacyl-CoA racemase
+ORPHANET:79094	Grange syndrome	ENSEMBL:ENSG00000163374	YY1 associated protein 1
+ORPHANET:566175	Complement hyperactivation-angiopathic thrombosis-protein-losing enteropathy syndrome	ENSEMBL:ENSG00000196352	CD55 molecule (Cromer blood group)
+ORPHANET:79096	Pyridoxal phosphate-responsive seizures	ENSEMBL:ENSG00000108439	pyridoxamine 5'-phosphate oxidase
+ORPHANET:79137	Generalized epilepsy-paroxysmal dyskinesia syndrome	ENSEMBL:ENSG00000156113	potassium calcium-activated channel subfamily M alpha 1
+ORPHANET:79124	Hepatic veno-occlusive disease-immunodeficiency syndrome	ENSEMBL:ENSG00000135899	SP110 nuclear body protein
+ORPHANET:566396	Chronic mast cell leukemia	ENSEMBL:ENSG00000157404	KIT proto-oncogene, receptor tyrosine kinase
+ORPHANET:77293	Chronic visceral acid sphingomyelinase deficiency	ENSEMBL:ENSG00000166311	sphingomyelin phosphodiesterase 1
+ORPHANET:77295	Odontoleukodystrophy	ENSEMBL:ENSG00000148606	RNA polymerase III subunit A
+ORPHANET:77261	Gaucher disease type 3	ENSEMBL:ENSG00000177628	glucosylceramidase beta 1
+ORPHANET:77292	Infantile neurovisceral acid sphingomyelinase deficiency	ENSEMBL:ENSG00000166311	sphingomyelin phosphodiesterase 1
+ORPHANET:77298	Anophthalmia/microphthalmia-esophageal atresia syndrome	ENSEMBL:ENSG00000181449	SRY-box transcription factor 2
+ORPHANET:77297	Majeed syndrome	ENSEMBL:ENSG00000101577	lipin 2
+ORPHANET:567502	B-cell immunodeficiency-limb anomaly-urogenital malformation syndrome	ENSEMBL:ENSG00000077097	DNA topoisomerase II beta
+ORPHANET:77301	Monosomy 9q22.3	ENSEMBL:ENSG00000185920	patched 1
+ORPHANET:79083	PPARG-related familial partial lipodystrophy	ENSEMBL:ENSG00000132170	peroxisome proliferator activated receptor gamma
+ORPHANET:79087	Acquired partial lipodystrophy	ENSEMBL:ENSG00000176619	lamin B2
+ORPHANET:79085	AKT2-related familial partial lipodystrophy	ENSEMBL:ENSG00000105221	AKT serine/threonine kinase 2
+ORPHANET:79084	Familial partial lipodystrophy, Köbberling type	ENSEMBL:ENSG00000160789	lamin A/C
+ORPHANET:79091	Hereditary inclusion body myopathy-joint contractures-ophthalmoplegia syndrome	ENSEMBL:ENSG00000125414	myosin heavy chain 2
+ORPHANET:75391	Primary immunodeficiency with natural-killer cell deficiency and adrenal insufficiency	ENSEMBL:ENSG00000104738	minichromosome maintenance complex component 4
+ORPHANET:75496	B4GALT7-related spondylodysplastic Ehlers-Danlos syndrome	ENSEMBL:ENSG00000027847	beta-1,4-galactosyltransferase 7
+ORPHANET:75497	X-linked Ehlers-Danlos syndrome	ENSEMBL:ENSG00000196924	filamin A
+ORPHANET:75563	X-linked sideroblastic anemia	ENSEMBL:ENSG00000158578	5'-aminolevulinate synthase 2
+ORPHANET:75857	6q terminal deletion syndrome	ENSEMBL:ENSG00000130023	ER membrane associated RNA degradation
+ORPHANET:75858	MORM syndrome	ENSEMBL:ENSG00000148384	inositol polyphosphate-5-phosphatase E
+ORPHANET:77258	Trichorhinophalangeal syndrome type 1 and 3	ENSEMBL:ENSG00000104447	transcriptional repressor GATA binding 1
+ORPHANET:77260	Gaucher disease type 2	ENSEMBL:ENSG00000177628	glucosylceramidase beta 1
+ORPHANET:569821	Congenital primary lymphedema of Gordon	ENSEMBL:ENSG00000150630	vascular endothelial growth factor C
+ORPHANET:73272	Growth delay due to insulin-like growth factor type 1 deficiency	ENSEMBL:ENSG00000017427	insulin like growth factor 1
+ORPHANET:73273	Growth delay due to insulin-like growth factor I resistance	ENSEMBL:ENSG00000140443	insulin like growth factor 1 receptor
+ORPHANET:75326	Retinal arterial tortuosity	ENSEMBL:ENSG00000187498	collagen type IV alpha 1 chain
+ORPHANET:75234	Cholesteryl ester storage disease	ENSEMBL:ENSG00000107798	lipase A, lysosomal acid type
+ORPHANET:75233	Wolman disease	ENSEMBL:ENSG00000107798	lipase A, lysosomal acid type
+ORPHANET:71526	Obesity due to pro-opiomelanocortin deficiency	ENSEMBL:ENSG00000115138	proopiomelanocortin
+ORPHANET:71528	Obesity due to prohormone convertase I deficiency	ENSEMBL:ENSG00000175426	proprotein convertase subtilisin/kexin type 1
+ORPHANET:71529	Obesity due to melanocortin 4 receptor deficiency	ENSEMBL:ENSG00000166603	melanocortin 4 receptor
+ORPHANET:71517	Rapid-onset dystonia-parkinsonism	ENSEMBL:ENSG00000105409	ATPase Na+/K+ transporting subunit alpha 3
+ORPHANET:71518	Benign paroxysmal torticollis of infancy	ENSEMBL:ENSG00000141837	calcium voltage-gated channel subunit alpha1 A
+ORPHANET:569274	Multiple mitochondrial dysfunctions syndrome type 5	ENSEMBL:ENSG00000135070	iron-sulfur cluster assembly 1
+ORPHANET:569290	Multiple mitochondrial dysfunctions syndrome type 6	ENSEMBL:ENSG00000105819	peptidase, mitochondrial processing subunit beta
+ORPHANET:569248	Microcystic stromal tumor	ENSEMBL:ENSG00000168036	catenin beta 1
+ORPHANET:73229	HANAC syndrome	ENSEMBL:ENSG00000187498	collagen type IV alpha 1 chain
+ORPHANET:40050	NON RARE IN EUROPE: Psoriatic arthritis	ENSEMBL:ENSG00000232810	tumor necrosis factor
+ORPHANET:530849	Familial apolipoprotein A5 deficiency	ENSEMBL:ENSG00000110243	apolipoprotein A5
+ORPHANET:530838	KRT1-related diffuse nonepidermolytic keratoderma	ENSEMBL:ENSG00000167768	keratin 1
+ORPHANET:38874	Dihydropyrimidinuria	ENSEMBL:ENSG00000147647	dihydropyrimidinase
+ORPHANET:530303	Progressive dementia with neuroserpin inclusion bodies	ENSEMBL:ENSG00000163536	serpin family I member 1
+ORPHANET:37612	Episodic ataxia type 1	ENSEMBL:ENSG00000111262	potassium voltage-gated channel subfamily A member 1
+ORPHANET:37042	Immune dysregulation-polyendocrinopathy-enteropathy-X-linked syndrome	ENSEMBL:ENSG00000049768	forkhead box P3
+ORPHANET:41751	Bietti crystalline dystrophy	ENSEMBL:ENSG00000145476	cytochrome P450 family 4 subfamily V member 2
+ORPHANET:35706	Glutaric acidemia type 3	ENSEMBL:ENSG00000175600	succinyl-CoA:glutarate-CoA transferase
+ORPHANET:35704	L-Arginine:glycine amidinotransferase deficiency	ENSEMBL:ENSG00000171766	glycine amidinotransferase
+ORPHANET:35710	Glucose-galactose malabsorption	ENSEMBL:ENSG00000100170	solute carrier family 5 member 1
+ORPHANET:35737	Morning glory disc anomaly	ENSEMBL:ENSG00000007372	paired box 6
+ORPHANET:35708	Aromatic L-amino acid decarboxylase deficiency	ENSEMBL:ENSG00000132437	dopa decarboxylase
+ORPHANET:35689	Primary lateral sclerosis	ENSEMBL:ENSG00000197912	SPG7 matrix AAA peptidase subunit, paraplegin
+ORPHANET:35701	3-hydroxy-3-methylglutaryl-CoA synthase deficiency	ENSEMBL:ENSG00000134240	3-hydroxy-3-methylglutaryl-CoA synthase 2
+ORPHANET:35173	X-linked dominant chondrodysplasia punctata	ENSEMBL:ENSG00000147155	EBP cholestenol delta-isomerase
+ORPHANET:35664	ALDH18A1-related De Barsy syndrome	ENSEMBL:ENSG00000059573	aldehyde dehydrogenase 18 family member A1
+ORPHANET:35120	Hemolytic anemia due to pyrimidine 5' nucleotidase deficiency	ENSEMBL:ENSG00000122643	5'-nucleotidase, cytosolic IIIA
+ORPHANET:35107	Desmosterolosis	ENSEMBL:ENSG00000116133	24-dehydrocholesterol reductase
+ORPHANET:35122	Congenital sucrase-isomaltase deficiency	ENSEMBL:ENSG00000090402	sucrase-isomaltase
+ORPHANET:36412	Hypocomplementemic urticarial vasculitis	ENSEMBL:ENSG00000163687	deoxyribonuclease 1 like 3
+ORPHANET:36355	Bleeding disorder due to P2Y12 defect	ENSEMBL:ENSG00000169313	purinergic receptor P2Y12
+ORPHANET:36367	Distal monosomy 1q	ENSEMBL:ENSG00000179456	zinc finger and BTB domain containing 18
+ORPHANET:36383	COL4A1-related familial vascular leukoencephalopathy	ENSEMBL:ENSG00000187498	collagen type IV alpha 1 chain
+ORPHANET:35878	Hyperinsulinism-hyperammonemia syndrome	ENSEMBL:ENSG00000148672	glutamate dehydrogenase 1
+ORPHANET:33572	5-oxoprolinase deficiency	ENSEMBL:ENSG00000178814	5-oxoprolinase, ATP-hydrolysing
+ORPHANET:33543	Kleine-Levin syndrome	ENSEMBL:ENSG00000168016	tetratricopeptide repeat and ankyrin repeat containing 1
+ORPHANET:33445	Neuroectodermal melanolysosomal disease	ENSEMBL:ENSG00000197535	myosin VA
+ORPHANET:535458	Familial GPIHBP1 deficiency	ENSEMBL:ENSG00000277494	glycosylphosphatidylinositol anchored high density lipoprotein binding protein 1
+ORPHANET:34217	Naxos disease	ENSEMBL:ENSG00000173801	junction plakoglobin
+ORPHANET:34145	NON RARE IN EUROPE: Berger disease	ENSEMBL:ENSG00000159640	angiotensin I converting enzyme
+ORPHANET:33574	Glutamate-cysteine ligase deficiency	ENSEMBL:ENSG00000001084	glutamate-cysteine ligase catalytic subunit
+ORPHANET:33573	Gamma-glutamyl transpeptidase deficiency	ENSEMBL:ENSG00000100031	gamma-glutamyltransferase 1
+ORPHANET:33067	Metaphyseal chondrodysplasia, Jansen type	ENSEMBL:ENSG00000160801	parathyroid hormone 1 receptor
+ORPHANET:33001	Lymphedema-distichiasis syndrome	ENSEMBL:ENSG00000176692	forkhead box C2
+ORPHANET:33355	Reticular dysgenesis	ENSEMBL:ENSG00000004455	adenylate kinase 2
+ORPHANET:535453	Familial lipase maturation factor 1 deficiency	ENSEMBL:ENSG00000103227	lipase maturation factor 1
+ORPHANET:33226	Waldenström macroglobulinemia	ENSEMBL:ENSG00000172936	MYD88 innate immune signal transduction adaptor
+ORPHANET:35056	NON RARE IN EUROPE: Trimethylaminuria	ENSEMBL:ENSG00000007933	flavin containing dimethylaniline monoxygenase 3
+ORPHANET:35069	Infantile neuroaxonal dystrophy	ENSEMBL:ENSG00000184381	phospholipase A2 group VI
+ORPHANET:35078	T-B+ severe combined immunodeficiency due to JAK3 deficiency	ENSEMBL:ENSG00000105639	Janus kinase 3
+ORPHANET:34520	Congenital muscular dystrophy with integrin alpha-7 deficiency	ENSEMBL:ENSG00000135424	integrin subunit alpha 7
+ORPHANET:34514	Telethonin-related limb-girdle muscular dystrophy R7	ENSEMBL:ENSG00000173991	titin-cap
+ORPHANET:34515	FKRP-related limb-girdle muscular dystrophy R9	ENSEMBL:ENSG00000181027	fukutin related protein
+ORPHANET:34516	DNAJB6-related limb-girdle muscular dystrophy D1	ENSEMBL:ENSG00000105993	DnaJ heat shock protein family (Hsp40) member B6
+ORPHANET:34587	Glycogen storage disease due to LAMP-2 deficiency	ENSEMBL:ENSG00000005893	lysosomal associated membrane protein 2
+ORPHANET:34528	Autosomal dominant primary hypomagnesemia with hypocalciuria	ENSEMBL:ENSG00000137731	FXYD domain containing ion transport regulator 2
+ORPHANET:536516	Myopathic Ehlers-Danlos syndrome	ENSEMBL:ENSG00000111799	collagen type XII alpha 1 chain
+ORPHANET:536467	B3GALT6-related spondylodysplastic Ehlers-Danlos syndrome	ENSEMBL:ENSG00000176022	beta-1,3-galactosyltransferase 6
+ORPHANET:536532	Classical-like Ehlers-Danlos syndrome type 2	ENSEMBL:ENSG00000106624	AE binding protein 1
+ORPHANET:537072	PLG-related hereditary angioedema with normal C1Inh	ENSEMBL:ENSG00000122194	plasminogen
+ORPHANET:32960	Tumor necrosis factor receptor 1 associated periodic syndrome	ENSEMBL:ENSG00000067182	TNF receptor superfamily member 1A
+ORPHANET:52530	Pseudo-von Willebrand disease	ENSEMBL:ENSG00000185245	glycoprotein Ib platelet subunit alpha
+ORPHANET:52503	X-linked creatine transporter deficiency	ENSEMBL:ENSG00000130821	solute carrier family 6 member 8
+ORPHANET:52055	Corpus callosum agenesis-intellectual disability-coloboma-micrognathia syndrome	ENSEMBL:ENSG00000089289	immunoglobulin binding protein 1
+ORPHANET:52368	Mohr-Tranebjaerg syndrome	ENSEMBL:ENSG00000126953	translocase of inner mitochondrial membrane 8A
+ORPHANET:53271	Muenke syndrome	ENSEMBL:ENSG00000068078	fibroblast growth factor receptor 3
+ORPHANET:53347	Brody myopathy	ENSEMBL:ENSG00000196296	ATPase sarcoplasmic/endoplasmic reticulum Ca2+ transporting 1
+ORPHANET:53035	Caroli disease	ENSEMBL:ENSG00000170927	PKHD1 ciliary IPT domain containing fibrocystin/polyductin
+ORPHANET:52901	Isolated follicle stimulating hormone deficiency	ENSEMBL:ENSG00000131808	follicle stimulating hormone subunit beta
+ORPHANET:53690	Congenital lactase deficiency	ENSEMBL:ENSG00000115850	lactase
+ORPHANET:53689	Congenital chloride diarrhea	ENSEMBL:ENSG00000091138	solute carrier family 26 member 3
+ORPHANET:53583	Paroxysmal dystonic choreathetosis with episodic ataxia and spasticity	ENSEMBL:ENSG00000117394	solute carrier family 2 member 1
+ORPHANET:53540	Goldmann-Favre syndrome	ENSEMBL:ENSG00000278570	nuclear receptor subfamily 2 group E member 3
+ORPHANET:53351	X-linked dystonia-parkinsonism	ENSEMBL:ENSG00000147133	TATA-box binding protein associated factor 1
+ORPHANET:538934	X-linked lymphoproliferative disease due to XIAP deficiency	ENSEMBL:ENSG00000101966	X-linked inhibitor of apoptosis
+ORPHANET:538931	X-linked lymphoproliferative disease due to SH2D1A deficiency	ENSEMBL:ENSG00000183918	SH2 domain containing 1A
+ORPHANET:53698	Myosin storage myopathy	ENSEMBL:ENSG00000092054	myosin heavy chain 7
+ORPHANET:53696	Arthrogryposis-anterior horn cell disease syndrome	ENSEMBL:ENSG00000119392	GLE1 RNA export mediator
+ORPHANET:53697	Gnathodiaphyseal dysplasia	ENSEMBL:ENSG00000171714	anoctamin 5
+ORPHANET:53691	Congenital cornea plana	ENSEMBL:ENSG00000139330	keratocan
+ORPHANET:53693	GRACILE syndrome	ENSEMBL:ENSG00000074582	BCS1 homolog, ubiquinol-cytochrome c reductase complex chaperone
+ORPHANET:48818	Aceruloplasminemia	ENSEMBL:ENSG00000047457	ceruloplasmin
+ORPHANET:538958	Combined immunodeficiency due to CD70 deficiency	ENSEMBL:ENSG00000125726	CD70 molecule
+ORPHANET:48431	Congenital cataracts-facial dysmorphism-neuropathy syndrome	ENSEMBL:ENSG00000060069	CTD phosphatase subunit 1
+ORPHANET:538963	Combined immunodeficiency due to ITK deficiency	ENSEMBL:ENSG00000113263	IL2 inducible T cell kinase
+ORPHANET:48652	Monosomy 22q13.3	ENSEMBL:ENSG00000251322	SH3 and multiple ankyrin repeat domains 3
+ORPHANET:50814	Craniolenticulosutural dysplasia	ENSEMBL:ENSG00000100934	SEC23 homolog A, COPII coat complex component
+ORPHANET:49827	Thiamine-responsive megaloblastic anemia syndrome	ENSEMBL:ENSG00000117479	solute carrier family 19 member 2
+ORPHANET:50251	Pleural mesothelioma	ENSEMBL:ENSG00000163930	BRCA1 associated protein 1
+ORPHANET:50945	Blomstrand lethal chondrodysplasia	ENSEMBL:ENSG00000160801	parathyroid hormone 1 receptor
+ORPHANET:50944	Schöpf-Schulz-Passarge syndrome	ENSEMBL:ENSG00000135925	Wnt family member 10A
+ORPHANET:50943	Keratolytic winter erythema	ENSEMBL:ENSG00000164733	cathepsin B
+ORPHANET:51188	Ethylmalonic encephalopathy	ENSEMBL:ENSG00000105755	ETHE1 persulfide dioxygenase
+ORPHANET:541423	Growth delay-intellectual disability-hepatopathy syndrome	ENSEMBL:ENSG00000196305	isoleucyl-tRNA synthetase 1
+ORPHANET:51208	Formiminoglutamic aciduria	ENSEMBL:ENSG00000160282	formimidoyltransferase cyclodeaminase
+ORPHANET:51636	WHIM syndrome	ENSEMBL:ENSG00000121966	C-X-C motif chemokine receptor 4
+ORPHANET:542306	GNB5-related intellectual disability-cardiac arrhythmia syndrome	ENSEMBL:ENSG00000069966	G protein subunit beta 5
+ORPHANET:542301	Combined immunodeficiency due to CARMIL2 deficiency	ENSEMBL:ENSG00000159753	capping protein regulator and myosin 1 linker 2
+ORPHANET:542310	Leukoencephalopathy with calcifications and cysts	ENSEMBL:ENSG00000200463	small nucleolar RNA, C/D box 118
+ORPHANET:42665	Tietz syndrome	ENSEMBL:ENSG00000187098	melanocyte inducing transcription factor
+ORPHANET:542585	Auditory neuropathy-optic atrophy syndrome	ENSEMBL:ENSG00000161513	ferredoxin reductase
+ORPHANET:43115	Hereditary myopathy with lactic acidosis due to ISCU deficiency	ENSEMBL:ENSG00000136003	iron-sulfur cluster assembly enzyme
+ORPHANET:45448	Miyoshi myopathy	ENSEMBL:ENSG00000135636	dysferlin
+ORPHANET:543470	Optic atrophy-ataxia-peripheral neuropathy-global developmental delay syndrome	ENSEMBL:ENSG00000161513	ferredoxin reductase
+ORPHANET:542657	Isolated hyperchlorhidrosis	ENSEMBL:ENSG00000074410	carbonic anhydrase 12
+ORPHANET:544254	SYNGAP1-related developmental and epileptic encephalopathy	ENSEMBL:ENSG00000197283	synaptic Ras GTPase activating protein 1
+ORPHANET:46059	Lathosterolosis	ENSEMBL:ENSG00000109929	sterol-C5-desaturase
+ORPHANET:47044	Hereditary papillary renal cell carcinoma	ENSEMBL:ENSG00000105976	MET proto-oncogene, receptor tyrosine kinase
+ORPHANET:46627	Char syndrome	ENSEMBL:ENSG00000008196	transcription factor AP-2 beta
+ORPHANET:544503	RNF13-related severe early-onset epileptic encephalopathy	ENSEMBL:ENSG00000082996	ring finger protein 13
+ORPHANET:544488	Global developmental delay-alopecia-macrocephaly-facial dysmorphism-structural brain anomalies syndrome	ENSEMBL:ENSG00000115758	ornithine decarboxylase 1
+ORPHANET:544469	PRUNE1-related neurological syndrome	ENSEMBL:ENSG00000143363	prune exopolyphosphatase 1
+ORPHANET:47045	Familial cold urticaria	ENSEMBL:ENSG00000162711	NLR family pyrin domain containing 3
+ORPHANET:544628	Atypical Fanconi syndrome-neonatal hyperinsulinism syndrome	ENSEMBL:ENSG00000101076	hepatocyte nuclear factor 4 alpha
+ORPHANET:544602	Congenital myopathy with reduced type 2 muscle fibers	ENSEMBL:ENSG00000168530	myosin light chain 1
+ORPHANET:555402	NAD(P)HX dehydratase deficiency	ENSEMBL:ENSG00000213995	NAD(P)HX dehydratase
+ORPHANET:555407	NAD(P)HX epimerase deficiency	ENSEMBL:ENSG00000163382	NAD(P)HX epimerase
+ORPHANET:555877	FLNA-related X-linked myxomatous valvular dysplasia	ENSEMBL:ENSG00000196924	filamin A
+ORPHANET:556030	Early-onset familial hypoaldosteronism	ENSEMBL:ENSG00000179142	cytochrome P450 family 11 subfamily B member 2
+ORPHANET:556985	Early-onset calcifying leukoencephalopathy-skeletal dysplasia	ENSEMBL:ENSG00000182578	colony stimulating factor 1 receptor
+ORPHANET:556955	Pancreatic agenesis-holoprosencephaly syndrome	ENSEMBL:ENSG00000125107	CCR4-NOT transcription complex subunit 1
+ORPHANET:557064	Neonatal epileptic encephalopathy due to glutaminase deficiency	ENSEMBL:ENSG00000115419	glutaminase
+ORPHANET:557056	Spastic ataxia-dysarthria due to glutaminase deficiency	ENSEMBL:ENSG00000115419	glutaminase
+ORPHANET:557003	Oculoskeletodental syndrome	ENSEMBL:ENSG00000011405	phosphatidylinositol-4-phosphate 3-kinase catalytic subunit type 2 alpha
+ORPHANET:519388	Autosomal recessive anterior segment dysgenesis	ENSEMBL:ENSG00000160111	C3 and PZP like alpha-2-macroglobulin domain containing 8
+ORPHANET:90045	Hereditary folate malabsorption	ENSEMBL:ENSG00000076351	solute carrier family 46 member 1
+ORPHANET:90039	Hemoglobin D disease	ENSEMBL:ENSG00000244734	hemoglobin subunit beta
+ORPHANET:90044	Familial pseudohyperkalemia	ENSEMBL:ENSG00000115657	ATP binding cassette subfamily B member 6 (Langereis blood group)
+ORPHANET:90042	Primary familial polycythemia	ENSEMBL:ENSG00000187266	erythropoietin receptor
+ORPHANET:90024	Deafness with labyrinthine aplasia, microtia, and microdontia	ENSEMBL:ENSG00000186895	fibroblast growth factor 3
+ORPHANET:90023	Primary immunodeficiency syndrome due to LAMTOR2 deficiency	ENSEMBL:ENSG00000116586	late endosomal/lysosomal adaptor, MAPK and MTOR activator 2
+ORPHANET:90031	Non-spherocytic hemolytic anemia due to hexokinase deficiency	ENSEMBL:ENSG00000156515	hexokinase 1
+ORPHANET:90030	Hemolytic anemia due to glutathione reductase deficiency	ENSEMBL:ENSG00000104687	glutathione-disulfide reductase
+ORPHANET:89936	X-linked hypophosphatemia	ENSEMBL:ENSG00000102174	phosphate regulating endopeptidase X-linked
+ORPHANET:89843	Dystrophic epidermolysis bullosa pruriginosa	ENSEMBL:ENSG00000114270	collagen type VII alpha 1 chain
+ORPHANET:89842	Autosomal recessive generalized dystrophic epidermolysis bullosa, intermediate form	ENSEMBL:ENSG00000114270	collagen type VII alpha 1 chain
+ORPHANET:89937	Autosomal dominant hypophosphatemic rickets	ENSEMBL:ENSG00000118972	fibroblast growth factor 23
+ORPHANET:90340	Blau syndrome	ENSEMBL:ENSG00000167207	nucleotide binding oligomerization domain containing 2
+ORPHANET:90342	Xeroderma pigmentosum variant	ENSEMBL:ENSG00000170734	DNA polymerase eta
+ORPHANET:90308	Klippel-Trénaunay syndrome	ENSEMBL:ENSG00000164252	angiogenic factor with G-patch and FHA domains 1
+ORPHANET:90307	Parkes Weber syndrome	ENSEMBL:ENSG00000145715	RAS p21 protein activator 1
+ORPHANET:90154	Mandibuloacral dysplasia with type B lipodystrophy	ENSEMBL:ENSG00000084073	zinc metallopeptidase STE24
+ORPHANET:90186	Meige disease	ENSEMBL:ENSG00000196411	EPH receptor B4
+ORPHANET:90118	Severe early-onset axonal neuropathy due to MFN2 deficiency	ENSEMBL:ENSG00000116688	mitofusin 2
+ORPHANET:90117	Hereditary motor and sensory neuropathy, Okinawa type	ENSEMBL:ENSG00000114354	trafficking from ER to golgi regulator
+ORPHANET:88644	Autosomal recessive ataxia, Beauce type	ENSEMBL:ENSG00000131018	spectrin repeat containing nuclear envelope protein 1
+ORPHANET:88639	Neurodegeneration due to 3-hydroxyisobutyryl-CoA hydrolase deficiency	ENSEMBL:ENSG00000198130	3-hydroxyisobutyryl-CoA hydrolase
+ORPHANET:88635	Vacuolar myopathy with sarcoplasmic reticulum protein aggregates	ENSEMBL:ENSG00000143318	calsequestrin 1
+ORPHANET:88621	Ichthyosis-prematurity syndrome	ENSEMBL:ENSG00000167114	solute carrier family 27 member 4
+ORPHANET:88628	Posterior column ataxia-retinitis pigmentosa syndrome	ENSEMBL:ENSG00000162769	FLVCR heme transporter 1
+ORPHANET:88629	Tritanopia	ENSEMBL:ENSG00000128617	opsin 1, short wave sensitive
+ORPHANET:88630	Terminal osseous dysplasia-pigmentary defects syndrome	ENSEMBL:ENSG00000196924	filamin A
+ORPHANET:88619	Familial acute necrotizing encephalopathy	ENSEMBL:ENSG00000153201	RAN binding protein 2
+ORPHANET:88618	S-adenosylhomocysteine hydrolase deficiency	ENSEMBL:ENSG00000101444	adenosylhomocysteinase
+ORPHANET:87503	Mal de Meleda	ENSEMBL:ENSG00000126233	secreted LY6/PLAUR domain containing 1
+ORPHANET:86920	Dermatopathia pigmentosa reticularis	ENSEMBL:ENSG00000186847	keratin 14
+ORPHANET:522077	Infantile hypotonia-oculomotor anomalies-hyperkinetic movements-developmental delay syndrome	ENSEMBL:ENSG00000067715	synaptotagmin 1
+ORPHANET:86911	Epilepsy with myoclonic absences	ENSEMBL:ENSG00000117394	solute carrier family 2 member 1
+ORPHANET:521450	LAMA5-related multisystemic syndrome	ENSEMBL:ENSG00000130702	laminin subunit alpha 5
+ORPHANET:521445	Microcephaly-facial dysmorphism-ocular anomalies-multiple congenital anomalies syndrome	ENSEMBL:ENSG00000178031	ADAMTS like 1
+ORPHANET:521432	Congenital cataract-severe neonatal hepatopathy-global developmental delay syndrome	ENSEMBL:ENSG00000001630	cytochrome P450 family 51 subfamily A member 1
+ORPHANET:521426	PLAA-associated neurodevelopmental disorder	ENSEMBL:ENSG00000137055	phospholipase A2 activating protein
+ORPHANET:521414	Autosomal dominant Charcot-Marie-Tooth disease type 2DD	ENSEMBL:ENSG00000163399	ATPase Na+/K+ transporting subunit alpha 1
+ORPHANET:521258	Xq25 microduplication syndrome	ENSEMBL:ENSG00000101972	stromal antigen 2
+ORPHANET:521305	Proximal myopathy with focal depletion of mitochondria	ENSEMBL:ENSG00000100288	choline kinase beta
+ORPHANET:521390	Spastic paraplegia-intellectual disability-nystagmus-obesity syndrome	ENSEMBL:ENSG00000134313	kinase D interacting substrate 220
+ORPHANET:521399	NON RARE IN EUROPE: Non rare obesity	ENSEMBL:ENSG00000171435	kinase suppressor of ras 2
+ORPHANET:521406	Dystonia-parkinsonism-hypermanganesemia syndrome	ENSEMBL:ENSG00000104635	solute carrier family 39 member 14
+ORPHANET:89838	Autosomal recessive generalized epidermolysis bullosa simplex	ENSEMBL:ENSG00000186847	keratin 14
+ORPHANET:521411	Autosomal recessive axonal Charcot-Marie-Tooth disease due to copper metabolism defect	ENSEMBL:ENSG00000284194	synthesis of cytochrome C oxidase 2
+ORPHANET:88949	MUC1-related autosomal dominant tubulointerstitial kidney disease	ENSEMBL:ENSG00000185499	mucin 1, cell surface associated
+ORPHANET:88950	UMOD-related autosomal dominant tubulointerstitial kidney disease	ENSEMBL:ENSG00000169344	uromodulin
+ORPHANET:88940	Pseudohypoaldosteronism type 2C	ENSEMBL:ENSG00000060237	WNK lysine deficient protein kinase 1
+ORPHANET:88939	Pseudohypoaldosteronism type 2B	ENSEMBL:ENSG00000126562	WNK lysine deficient protein kinase 4
+ORPHANET:88917	X-linked Alport syndrome	ENSEMBL:ENSG00000188153	collagen type IV alpha 5 chain
+ORPHANET:93256	Fragile X-associated tremor/ataxia syndrome	ENSEMBL:ENSG00000102081	fragile X messenger ribonucleoprotein 1
+ORPHANET:528105	Hypohidrosis-electrolyte imbalance-lacrimal gland dysfunction-ichthyosis-xerostomia syndrome	ENSEMBL:ENSG00000134873	claudin 10
+ORPHANET:528091	Hydrops-lactic acidosis-sideroblastic anemia-multisystemic failure syndrome	ENSEMBL:ENSG00000011376	leucyl-tRNA synthetase 2, mitochondrial
+ORPHANET:93262	Crouzon syndrome-acanthosis nigricans syndrome	ENSEMBL:ENSG00000068078	fibroblast growth factor receptor 3
+ORPHANET:93260	Pfeiffer syndrome type 3	ENSEMBL:ENSG00000066468	fibroblast growth factor receptor 2
+ORPHANET:93259	Pfeiffer syndrome type 2	ENSEMBL:ENSG00000066468	fibroblast growth factor receptor 2
+ORPHANET:93270	Short rib-polydactyly syndrome, Saldino-Noonan type	ENSEMBL:ENSG00000187240	dynein cytoplasmic 2 heavy chain 1
+ORPHANET:93282	Spondyloepimetaphyseal dysplasia, PAPSS2 type	ENSEMBL:ENSG00000198682	3'-phosphoadenosine 5'-phosphosulfate synthase 2
+ORPHANET:93283	Spondyloepiphyseal dysplasia, Kimberley type	ENSEMBL:ENSG00000157766	aggrecan
+ORPHANET:93279	Mild spondyloepiphyseal dysplasia due to COL2A1 mutation with early-onset osteoarthritis	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:93276	Polyostotic fibrous dysplasia	ENSEMBL:ENSG00000087460	GNAS complex locus
+ORPHANET:93277	Monostotic fibrous dysplasia	ENSEMBL:ENSG00000087460	GNAS complex locus
+ORPHANET:93274	Thanatophoric dysplasia type 2	ENSEMBL:ENSG00000068078	fibroblast growth factor receptor 3
+ORPHANET:527497	NKX6-2-related autosomal recessive hypomyelinating leukodystrophy	ENSEMBL:ENSG00000148826	NK6 homeobox 2
+ORPHANET:93110	Posterior urethral valve	ENSEMBL:ENSG00000173068	basonuclin 2
+ORPHANET:527450	Severe myopia-generalized joint laxity-short stature syndrome	ENSEMBL:ENSG00000125812	GDNF inducible zinc finger protein 1
+ORPHANET:527468	Diaphragmatic hernia-short bowel-asplenia syndrome	ENSEMBL:ENSG00000136630	H2.0 like homeobox
+ORPHANET:93160	Hypocalcemic vitamin D-resistant rickets	ENSEMBL:ENSG00000111424	vitamin D receptor
+ORPHANET:93114	Autosomal dominant intermediate Charcot-Marie-Tooth disease type E	ENSEMBL:ENSG00000203485	inverted formin, FH2 and WH2 domain containing
+ORPHANET:93111	HNF1B-related autosomal dominant tubulointerstitial kidney disease	ENSEMBL:ENSG00000275410	HNF1 homeobox B
+ORPHANET:93172	Renal dysplasia, unilateral	ENSEMBL:ENSG00000275410	HNF1 homeobox B
+ORPHANET:93173	Renal dysplasia, bilateral	ENSEMBL:ENSG00000275410	HNF1 homeobox B
+ORPHANET:93322	Tibial hemimelia	ENSEMBL:ENSG00000106571	GLI family zinc finger 3
+ORPHANET:93325	Autosomal dominant Kenny-Caffey syndrome	ENSEMBL:ENSG00000166801	FAM111 trypsin like peptidase A
+ORPHANET:93324	Autosomal recessive Kenny-Caffey syndrome	ENSEMBL:ENSG00000284770	tubulin folding cofactor E
+ORPHANET:93329	Autosomal recessive omodysplasia	ENSEMBL:ENSG00000183098	glypican 6
+ORPHANET:93328	Autosomal dominant omodysplasia	ENSEMBL:ENSG00000180340	frizzled class receptor 2
+ORPHANET:93333	Pelviscapular dysplasia	ENSEMBL:ENSG00000092607	T-box transcription factor 15
+ORPHANET:93339	Polydactyly of a biphalangeal thumb	ENSEMBL:ENSG00000111087	GLI family zinc finger 1
+ORPHANET:93338	Polysyndactyly	ENSEMBL:ENSG00000106571	GLI family zinc finger 3
+ORPHANET:93349	X-linked spondyloepimetaphyseal dysplasia	ENSEMBL:ENSG00000182492	biglycan
+ORPHANET:93346	Spondyloepimetaphyseal dysplasia congenita, Strudwick type	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:93356	Spondyloepimetaphyseal dysplasia, Missouri type	ENSEMBL:ENSG00000137745	matrix metallopeptidase 13
+ORPHANET:93352	Spondyloepimetaphyseal dysplasia, Shohat type	ENSEMBL:ENSG00000198171	DDRGK domain containing 1
+ORPHANET:93284	Spondyloepiphyseal dysplasia tarda	ENSEMBL:ENSG00000196459	trafficking protein particle complex subunit 2
+ORPHANET:93296	Achondrogenesis type 2	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:93298	Achondrogenesis type 1B	ENSEMBL:ENSG00000155850	solute carrier family 26 member 2
+ORPHANET:93297	Hypochondrogenesis	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:93299	Achondrogenesis type 1A	ENSEMBL:ENSG00000100815	thyroid hormone receptor interactor 11
+ORPHANET:93304	Autosomal dominant brachyolmia	ENSEMBL:ENSG00000111199	transient receptor potential cation channel subfamily V member 4
+ORPHANET:93307	Multiple epiphyseal dysplasia type 4	ENSEMBL:ENSG00000155850	solute carrier family 26 member 2
+ORPHANET:93308	Multiple epiphyseal dysplasia type 1	ENSEMBL:ENSG00000105664	cartilage oligomeric matrix protein
+ORPHANET:93311	Multiple epiphyseal dysplasia type 5	ENSEMBL:ENSG00000132031	matrilin 3
+ORPHANET:93314	Spondylometaphyseal dysplasia, Kozlowski type	ENSEMBL:ENSG00000111199	transient receptor potential cation channel subfamily V member 4
+ORPHANET:93316	Spondylometaphyseal dysplasia, Schmidt type	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:93317	Spondylometaphyseal dysplasia, Sedaghatian type	ENSEMBL:ENSG00000167468	glutathione peroxidase 4
+ORPHANET:90673	Hypothyroidism due to TSH receptor mutations	ENSEMBL:ENSG00000165409	thyroid stimulating hormone receptor
+ORPHANET:90674	Isolated thyroid-stimulating hormone deficiency	ENSEMBL:ENSG00000134200	thyroid stimulating hormone subunit beta
+ORPHANET:529831	Letrozole toxicity	ENSEMBL:ENSG00000255974	cytochrome P450 family 2 subfamily A member 6
+ORPHANET:529819	NON RARE IN EUROPE: Exfoliation syndrome	ENSEMBL:ENSG00000129038	lysyl oxidase like 1
+ORPHANET:90658	Charcot-Marie-Tooth disease type 1E	ENSEMBL:ENSG00000109099	peripheral myelin protein 22
+ORPHANET:90791	Congenital adrenal hyperplasia due to 3-beta-hydroxysteroid dehydrogenase deficiency	ENSEMBL:ENSG00000203859	hydroxy-delta-5-steroid dehydrogenase, 3 beta- and steroid delta-isomerase 2
+ORPHANET:529980	Inflammatory bowel disease-recurrent sinopulmonary infections syndrome	ENSEMBL:ENSG00000102908	nuclear factor of activated T cells 5
+ORPHANET:529977	Immune dysregulation-inflammatory bowel disease-arthritis-recurrent infections-lymphopenia syndrome	ENSEMBL:ENSG00000137275	receptor interacting serine/threonine kinase 1
+ORPHANET:529965	Intellectual disability-autism-speech apraxia-craniofacial dysmorphism syndrome	ENSEMBL:ENSG00000153922	chromodomain helicase DNA binding protein 1
+ORPHANET:529574	Duane retraction syndrome with congenital deafness	ENSEMBL:ENSG00000204103	MAF bZIP transcription factor B
+ORPHANET:90389	Telangiectasia macularis eruptiva perstans	ENSEMBL:ENSG00000157404	KIT proto-oncogene, receptor tyrosine kinase
+ORPHANET:90653	Stickler syndrome type 1	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:90652	Otopalatodigital syndrome type 2	ENSEMBL:ENSG00000196924	filamin A
+ORPHANET:90654	Stickler syndrome type 2	ENSEMBL:ENSG00000060718	collagen type XI alpha 1 chain
+ORPHANET:529665	Neurodevelopmental delay-seizures-ophthalmic anomalies-osteopenia-cerebellar atrophy syndrome	ENSEMBL:ENSG00000197858	glycosylphosphatidylinositol anchor attachment 1
+ORPHANET:90650	Otopalatodigital syndrome type 1	ENSEMBL:ENSG00000196924	filamin A
+ORPHANET:91496	Snowflake vitreoretinal degeneration	ENSEMBL:ENSG00000115474	potassium inwardly rectifying channel subfamily J member 13
+ORPHANET:91481	Ring dermoid of cornea	ENSEMBL:ENSG00000164093	paired like homeodomain 2
+ORPHANET:91414	Pilomatrixoma	ENSEMBL:ENSG00000168036	catenin beta 1
+ORPHANET:91490	Isolated congenital sclerocornea	ENSEMBL:ENSG00000121634	gap junction protein alpha 8
+ORPHANET:91489	Isolated congenital megalocornea	ENSEMBL:ENSG00000101938	chordin like 1
+ORPHANET:91130	Cardiomyopathy-hypotonia-lactic acidosis syndrome	ENSEMBL:ENSG00000075415	solute carrier family 25 member 3
+ORPHANET:91131	DK1-CDG	ENSEMBL:ENSG00000175283	dolichol kinase
+ORPHANET:91132	Ichthyosis-hypotrichosis syndrome	ENSEMBL:ENSG00000149418	ST14 transmembrane serine protease matriptase
+ORPHANET:90793	Congenital adrenal hyperplasia due to 17-alpha-hydroxylase deficiency	ENSEMBL:ENSG00000148795	cytochrome P450 family 17 subfamily A member 1
+ORPHANET:90795	Congenital adrenal hyperplasia due to 11-beta-hydroxylase deficiency	ENSEMBL:ENSG00000160882	cytochrome P450 family 11 subfamily B member 1
+ORPHANET:90797	Partial androgen insensitivity syndrome	ENSEMBL:ENSG00000169083	androgen receptor
+ORPHANET:91347	TSH-secreting pituitary adenoma	ENSEMBL:ENSG00000107736	cadherin related 23
+ORPHANET:91352	Germinoma of the central nervous system	ENSEMBL:ENSG00000171988	jumonji domain containing 1C
+ORPHANET:91135	Body skin hyperlaxity due to vitamin K-dependent coagulation factor deficiency	ENSEMBL:ENSG00000115486	gamma-glutamyl carboxylase
+ORPHANET:79395	Keratoderma hereditarium mutilans with ichthyosis	ENSEMBL:ENSG00000203782	loricrin cornified envelope precursor protein
+ORPHANET:79414	Woolly hair nevus	ENSEMBL:ENSG00000174775	HRas proto-oncogene, GTPase
+ORPHANET:79401	PLEC-related intermediate epidermolysis bullosa simplex without extracutaneous involvement	ENSEMBL:ENSG00000178209	plectin
+ORPHANET:79406	Late-onset junctional epidermolysis bullosa	ENSEMBL:ENSG00000065618	collagen type XVII alpha 1 chain
+ORPHANET:79409	Recessive dystrophic epidermolysis bullosa inversa	ENSEMBL:ENSG00000114270	collagen type VII alpha 1 chain
+ORPHANET:79411	Self-improving dystrophic epidermolysis bullosa	ENSEMBL:ENSG00000114270	collagen type VII alpha 1 chain
+ORPHANET:79410	Localized dystrophic epidermolysis bullosa, pretibial form	ENSEMBL:ENSG00000114270	collagen type VII alpha 1 chain
+ORPHANET:79455	Cutaneous mastocytoma	ENSEMBL:ENSG00000157404	KIT proto-oncogene, receptor tyrosine kinase
+ORPHANET:79435	Oculocutaneous albinism type 4	ENSEMBL:ENSG00000164175	solute carrier family 45 member 2
+ORPHANET:79434	Oculocutaneous albinism type 1B	ENSEMBL:ENSG00000077498	tyrosinase
+ORPHANET:79433	Oculocutaneous albinism type 3	ENSEMBL:ENSG00000107165	tyrosinase related protein 1
+ORPHANET:79431	Oculocutaneous albinism type 1A	ENSEMBL:ENSG00000077498	tyrosinase
+ORPHANET:79445	Pseudopseudohypoparathyroidism	ENSEMBL:ENSG00000087460	GNAS complex locus
+ORPHANET:79444	Pseudohypoparathyroidism type 1C	ENSEMBL:ENSG00000087460	GNAS complex locus
+ORPHANET:79443	Pseudohypoparathyroidism type 1A	ENSEMBL:ENSG00000087460	GNAS complex locus
+ORPHANET:79484	Phakomatosis cesiomarmorata	ENSEMBL:ENSG00000088256	G protein subunit alpha 11
+ORPHANET:79474	Atypical Werner syndrome	ENSEMBL:ENSG00000160789	lamin A/C
+ORPHANET:79477	Griscelli syndrome type 2	ENSEMBL:ENSG00000069974	RAB27A, member RAS oncogene family
+ORPHANET:79476	Griscelli syndrome type 1	ENSEMBL:ENSG00000197535	myosin VA
+ORPHANET:79473	Porphyria variegata	ENSEMBL:ENSG00000143224	protoporphyrinogen oxidase
+ORPHANET:79269	Sanfilippo syndrome type A	ENSEMBL:ENSG00000181523	N-sulfoglucosamine sulfohydrolase
+ORPHANET:79257	GM1 gangliosidosis type 3	ENSEMBL:ENSG00000170266	galactosidase beta 1
+ORPHANET:79256	GM1 gangliosidosis type 2	ENSEMBL:ENSG00000170266	galactosidase beta 1
+ORPHANET:79255	GM1 gangliosidosis type 1	ENSEMBL:ENSG00000170266	galactosidase beta 1
+ORPHANET:79254	Classic phenylketonuria	ENSEMBL:ENSG00000171759	phenylalanine hydroxylase
+ORPHANET:79259	Glycogen storage disease due to glucose-6-phosphatase deficiency type Ib	ENSEMBL:ENSG00000137700	solute carrier family 37 member 4
+ORPHANET:79258	Glycogen storage disease due to glucose-6-phosphatase deficiency type Ia	ENSEMBL:ENSG00000131482	glucose-6-phosphatase catalytic subunit 1
+ORPHANET:79246	Pyruvate dehydrogenase phosphatase deficiency	ENSEMBL:ENSG00000164951	pyruvate dehydrogenase phosphatase catalytic subunit 1
+ORPHANET:79253	Mild phenylketonuria	ENSEMBL:ENSG00000171759	phenylalanine hydroxylase
+ORPHANET:79240	Glycogen storage disease due to liver and muscle phosphorylase kinase deficiency	ENSEMBL:ENSG00000102893	phosphorylase kinase regulatory subunit beta
+ORPHANET:79241	Biotinidase deficiency	ENSEMBL:ENSG00000169814	biotinidase
+ORPHANET:79239	Classic galactosemia	ENSEMBL:ENSG00000213930	galactose-1-phosphate uridylyltransferase
+ORPHANET:79244	Pyruvate dehydrogenase E2 deficiency	ENSEMBL:ENSG00000150768	dihydrolipoamide S-acetyltransferase
+ORPHANET:79242	Holocarboxylase synthetase deficiency	ENSEMBL:ENSG00000159267	holocarboxylase synthetase
+ORPHANET:79299	Hyperinsulinism due to glucokinase deficiency	ENSEMBL:ENSG00000106633	glucokinase
+ORPHANET:79301	Congenital bile acid synthesis defect type 1	ENSEMBL:ENSG00000099377	hydroxy-delta-5-steroid dehydrogenase, 3 beta- and steroid delta-isomerase 7
+ORPHANET:79293	Familial LCAT deficiency	ENSEMBL:ENSG00000213398	lecithin-cholesterol acyltransferase
+ORPHANET:79292	Fish-eye disease	ENSEMBL:ENSG00000213398	lecithin-cholesterol acyltransferase
+ORPHANET:79278	Autosomal erythropoietic protoporphyria	ENSEMBL:ENSG00000066926	ferrochelatase
+ORPHANET:79279	Alpha-N-acetylgalactosaminidase deficiency type 1	ENSEMBL:ENSG00000198951	alpha-N-acetylgalactosaminidase
+ORPHANET:79280	Alpha-N-acetylgalactosaminidase deficiency type 2	ENSEMBL:ENSG00000198951	alpha-N-acetylgalactosaminidase
+ORPHANET:79281	Alpha-N-acetylgalactosaminidase deficiency type 3	ENSEMBL:ENSG00000198951	alpha-N-acetylgalactosaminidase
+ORPHANET:79282	Methylmalonic acidemia with homocystinuria, type cblC	ENSEMBL:ENSG00000132763	metabolism of cobalamin associated C
+ORPHANET:79283	Methylmalonic acidemia with homocystinuria, type cblD	ENSEMBL:ENSG00000168288	metabolism of cobalamin associated D
+ORPHANET:79284	Methylmalonic acidemia with homocystinuria type cblF	ENSEMBL:ENSG00000168216	LMBR1 domain containing 1
+ORPHANET:79270	Sanfilippo syndrome type B	ENSEMBL:ENSG00000108784	N-acetyl-alpha-glucosaminidase
+ORPHANET:79271	Sanfilippo syndrome type C	ENSEMBL:ENSG00000165102	heparan-alpha-glucosaminide N-acetyltransferase
+ORPHANET:79272	Sanfilippo syndrome type D	ENSEMBL:ENSG00000135677	glucosamine (N-acetyl)-6-sulfatase
+ORPHANET:79273	Hereditary coproporphyria	ENSEMBL:ENSG00000080819	coproporphyrinogen oxidase
+ORPHANET:79276	Acute intermittent porphyria	ENSEMBL:ENSG00000256269	hydroxymethylbilane synthase
+ORPHANET:79333	COG7-CDG	ENSEMBL:ENSG00000168434	component of oligomeric golgi complex 7
+ORPHANET:79332	B4GALT1-CDG	ENSEMBL:ENSG00000086062	beta-1,4-galactosyltransferase 1
+ORPHANET:79330	MOGS-CDG	ENSEMBL:ENSG00000115275	mannosyl-oligosaccharide glucosidase
+ORPHANET:79329	MGAT2-CDG	ENSEMBL:ENSG00000168282	alpha-1,6-mannosyl-glycoprotein 2-beta-N-acetylglucosaminyltransferase
+ORPHANET:79328	ALG9-CDG	ENSEMBL:ENSG00000086848	ALG9 alpha-1,2-mannosyltransferase
+ORPHANET:79327	ALG1-CDG	ENSEMBL:ENSG00000033011	ALG1 chitobiosyldiphosphodolichol beta-mannosyltransferase
+ORPHANET:79326	ALG2-CDG	ENSEMBL:ENSG00000119523	ALG2 alpha-1,3/1,6-mannosyltransferase
+ORPHANET:79325	ALG8-CDG	ENSEMBL:ENSG00000159063	ALG8 alpha-1,3-glucosyltransferase
+ORPHANET:79324	ALG12-CDG	ENSEMBL:ENSG00000182858	ALG12 alpha-1,6-mannosyltransferase
+ORPHANET:79323	MPDU1-CDG	ENSEMBL:ENSG00000129255	mannose-P-dolichol utilization defect 1
+ORPHANET:79322	DPM1-CDG	ENSEMBL:ENSG00000000419	dolichyl-phosphate mannosyltransferase subunit 1, catalytic
+ORPHANET:79321	ALG3-CDG	ENSEMBL:ENSG00000214160	ALG3 alpha-1,3- mannosyltransferase
+ORPHANET:79320	ALG6-CDG	ENSEMBL:ENSG00000088035	ALG6 alpha-1,3-glucosyltransferase
+ORPHANET:79319	MPI-CDG	ENSEMBL:ENSG00000178802	mannose phosphate isomerase
+ORPHANET:79318	PMM2-CDG	ENSEMBL:ENSG00000140650	phosphomannomutase 2
+ORPHANET:79314	L-2-hydroxyglutaric aciduria	ENSEMBL:ENSG00000087299	L-2-hydroxyglutarate dehydrogenase
+ORPHANET:79312	Vitamin B12-unresponsive methylmalonic acidemia type mut-	ENSEMBL:ENSG00000146085	methylmalonyl-CoA mutase
+ORPHANET:79310	Vitamin B12-responsive methylmalonic acidemia type cblA	ENSEMBL:ENSG00000151611	metabolism of cobalamin associated A
+ORPHANET:79311	Vitamin B12-responsive methylmalonic acidemia type cblB	ENSEMBL:ENSG00000139428	metabolism of cobalamin associated B
+ORPHANET:79304	Progressive familial intrahepatic cholestasis type 2	ENSEMBL:ENSG00000073734	ATP binding cassette subfamily B member 11
+ORPHANET:79305	Progressive familial intrahepatic cholestasis type 3	ENSEMBL:ENSG00000005471	ATP binding cassette subfamily B member 4
+ORPHANET:79302	Congenital bile acid synthesis defect type 3	ENSEMBL:ENSG00000172817	cytochrome P450 family 7 subfamily B member 1
+ORPHANET:79303	Congenital bile acid synthesis defect type 2	ENSEMBL:ENSG00000122787	aldo-keto reductase family 1 member D1
+ORPHANET:79351	3-phosphoglycerate dehydrogenase deficiency, infantile/juvenile form	ENSEMBL:ENSG00000092621	phosphoglycerate dehydrogenase
+ORPHANET:79350	3-phosphoserine phosphatase deficiency, infantile/juvenile form	ENSEMBL:ENSG00000146733	phosphoserine phosphatase
+ORPHANET:79345	Brachytelephalangic chondrodysplasia punctata	ENSEMBL:ENSG00000157399	arylsulfatase L
+ORPHANET:85195	Familial expansile osteolysis	ENSEMBL:ENSG00000141655	TNF receptor superfamily member 11a
+ORPHANET:85194	Spondylo-ocular syndrome	ENSEMBL:ENSG00000015532	xylosyltransferase 2
+ORPHANET:85198	Dysspondyloenchondromatosis	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:85201	Genitopatellar syndrome	ENSEMBL:ENSG00000156650	lysine acetyltransferase 6B
+ORPHANET:85200	Ischiovertebral syndrome	ENSEMBL:ENSG00000164619	BMP binding endothelial regulator
+ORPHANET:85202	Keutel syndrome	ENSEMBL:ENSG00000111341	matrix Gla protein
+ORPHANET:85212	Fetal Gaucher disease	ENSEMBL:ENSG00000177628	glucosylceramidase beta 1
+ORPHANET:85277	X-linked intellectual disability, Cantagrel type	ENSEMBL:ENSG00000050030	neurite extension and migration factor
+ORPHANET:85278	Christianson syndrome	ENSEMBL:ENSG00000198689	solute carrier family 9 member A6
+ORPHANET:85279	KDM5C-related syndromic X-linked intellectual disability	ENSEMBL:ENSG00000126012	lysine demethylase 5C
+ORPHANET:85282	MEHMO syndrome	ENSEMBL:ENSG00000130741	eukaryotic translation initiation factor 2 subunit gamma
+ORPHANET:85284	BRESEK syndrome	ENSEMBL:ENSG00000012174	membrane bound transcription factor peptidase, site 2
+ORPHANET:85287	X-linked intellectual disability, Siderius type	ENSEMBL:ENSG00000172943	PHD finger protein 8
+ORPHANET:85288	X-linked intellectual disability, Stocco Dos Santos type	ENSEMBL:ENSG00000158352	shroom family member 4
+ORPHANET:85293	X-linked intellectual disability, Cabezas type	ENSEMBL:ENSG00000158290	cullin 4B
+ORPHANET:85295	HSD10 disease, atypical type	ENSEMBL:ENSG00000072506	hydroxysteroid 17-beta dehydrogenase 10
+ORPHANET:85294	X-linked epilepsy-learning disabilities-behavior disorders syndrome	ENSEMBL:ENSG00000008056	synapsin I
+ORPHANET:85329	X-linked intellectual disability-hypotonia-facial dysmorphism-aggressive behavior syndrome	ENSEMBL:ENSG00000182287	adaptor related protein complex 1 subunit sigma 2
+ORPHANET:85335	Fried syndrome	ENSEMBL:ENSG00000182287	adaptor related protein complex 1 subunit sigma 2
+ORPHANET:85442	Short stature-pituitary and cerebellar defects-small sella turcica syndrome	ENSEMBL:ENSG00000121454	LIM homeobox 4
+ORPHANET:85445	AA amyloidosis	ENSEMBL:ENSG00000173432	serum amyloid A1
+ORPHANET:85453	X-linked reticulate pigmentary disorder	ENSEMBL:ENSG00000101868	DNA polymerase alpha 1, catalytic subunit
+ORPHANET:86788	X-linked severe congenital neutropenia	ENSEMBL:ENSG00000015285	WASP actin nucleation promoting factor
+ORPHANET:86309	DPAGT1-CDG	ENSEMBL:ENSG00000172269	dolichyl-phosphate N-acetylglucosaminephosphotransferase 1
+ORPHANET:85448	AGel amyloidosis	ENSEMBL:ENSG00000148180	gelsolin
+ORPHANET:85447	ATTRV30M amyloidosis	ENSEMBL:ENSG00000118271	transthyretin
+ORPHANET:85451	ATTRV122I amyloidosis	ENSEMBL:ENSG00000118271	transthyretin
+ORPHANET:86812	POMT1-related limb-girdle muscular dystrophy R11	ENSEMBL:ENSG00000130714	protein O-mannosyltransferase 1
+ORPHANET:86813	Helicoid peripapillary chorioretinal degeneration	ENSEMBL:ENSG00000187079	TEA domain transcription factor 1
+ORPHANET:86815	Aplasia of lacrimal and salivary glands	ENSEMBL:ENSG00000070193	fibroblast growth factor 10
+ORPHANET:86816	Congenital analbuminemia	ENSEMBL:ENSG00000163631	albumin
+ORPHANET:512017	Chronic lymphoproliferative disorder of natural killer cells	ENSEMBL:ENSG00000168610	signal transducer and activator of transcription 3
+ORPHANET:86817	Hemolytic anemia due to adenylate kinase deficiency	ENSEMBL:ENSG00000106992	adenylate kinase 1
+ORPHANET:86819	Atrichia with papular lesions	ENSEMBL:ENSG00000168453	HR lysine demethylase and nuclear receptor corepressor
+ORPHANET:86841	Myelodysplastic syndrome associated with isolated del(5q) chromosome abnormality	ENSEMBL:ENSG00000164587	ribosomal protein S14
+ORPHANET:512103	Autosomal recessive epidermolytic ichthyosis	ENSEMBL:ENSG00000186395	keratin 10
+ORPHANET:86830	Chronic myeloproliferative disease, unclassifiable	ENSEMBL:ENSG00000113721	platelet derived growth factor receptor beta
+ORPHANET:86829	Chronic neutrophilic leukemia	ENSEMBL:ENSG00000119535	colony stimulating factor 3 receptor
+ORPHANET:512260	Congenital cerebellar ataxia due to RNU12 mutation	ENSEMBL:ENSG00000276027	RNA, U12 small nuclear
+ORPHANET:86845	Acute myeloid leukaemia with myelodysplasia-related features	ENSEMBL:ENSG00000168769	tet methylcytosine dioxygenase 2
+ORPHANET:86872	T-cell large granular lymphocyte leukemia	ENSEMBL:ENSG00000168610	signal transducer and activator of transcription 3
+ORPHANET:86884	Subcutaneous panniculitis-like T-cell lymphoma	ENSEMBL:ENSG00000135077	hepatitis A virus cellular receptor 2
+ORPHANET:79503	Ichthyosis hystrix of Curth-Macklin	ENSEMBL:ENSG00000167768	keratin 1
+ORPHANET:79495	X-linked congenital generalized hypertrichosis	ENSEMBL:ENSG00000134595	SRY-box transcription factor 3
+ORPHANET:79499	Autosomal dominant deafness-onychodystrophy syndrome	ENSEMBL:ENSG00000147416	ATPase H+ transporting V1 subunit B2
+ORPHANET:79665	Gardner syndrome	ENSEMBL:ENSG00000134982	APC regulator of WNT signaling pathway
+ORPHANET:79643	Autosomal recessive hyperinsulinism due to SUR1 deficiency	ENSEMBL:ENSG00000006071	ATP binding cassette subfamily C member 8
+ORPHANET:79651	Mild hyperphenylalaninemia	ENSEMBL:ENSG00000171759	phenylalanine hydroxylase
+ORPHANET:79644	Autosomal recessive hyperinsulinism due to Kir6.2 deficiency	ENSEMBL:ENSG00000187486	potassium inwardly rectifying channel subfamily J member 11
+ORPHANET:83463	Microtia	ENSEMBL:ENSG00000105996	homeobox A2
+ORPHANET:83461	Congenital primary aphakia	ENSEMBL:ENSG00000186790	forkhead box E3
+ORPHANET:83454	Glomuvenous malformation	ENSEMBL:ENSG00000174842	glomulin, FKBP associated protein
+ORPHANET:83620	Enteric anendocrinosis	ENSEMBL:ENSG00000122859	neurogenin 3
+ORPHANET:84090	Fibronectin glomerulopathy	ENSEMBL:ENSG00000115414	fibronectin 1
+ORPHANET:513436	Autosomal recessive spastic paraplegia type 78	ENSEMBL:ENSG00000159363	ATPase cation transporting 13A2
+ORPHANET:83629	Leukoencephalopathy-spondyloepimetaphyseal dysplasia syndrome	ENSEMBL:ENSG00000156709	apoptosis inducing factor mitochondria associated 1
+ORPHANET:513456	Intellectual disability-seizures-abnormal gait-facial dysmorphism syndrome	ENSEMBL:ENSG00000162923	WD repeat domain 26
+ORPHANET:83642	Microcytic anemia with liver iron overload	ENSEMBL:ENSG00000110911	solute carrier family 11 member 2
+ORPHANET:85163	Hypomyelination-congenital cataract syndrome	ENSEMBL:ENSG00000122591	hyccin PI4KA lipid kinase complex subunit 1
+ORPHANET:85164	Camptodactyly-tall stature-scoliosis-hearing loss syndrome	ENSEMBL:ENSG00000068078	fibroblast growth factor receptor 3
+ORPHANET:85146	Neurogenic scapuloperoneal syndrome, Kaeser type	ENSEMBL:ENSG00000175084	desmin
+ORPHANET:85128	Bothnia retinal dystrophy	ENSEMBL:ENSG00000140522	retinaldehyde binding protein 1
+ORPHANET:85112	Palmoplantar keratoderma-XX sex reversal-predisposition to squamous cell carcinoma syndrome	ENSEMBL:ENSG00000169218	R-spondin 1
+ORPHANET:84132	Desmin-related myopathy with Mallory body-like inclusions	ENSEMBL:ENSG00000162430	selenoprotein N
+ORPHANET:85186	Endosteal sclerosis-cerebellar hypoplasia syndrome	ENSEMBL:ENSG00000013503	RNA polymerase III subunit B
+ORPHANET:85182	Diaphyseal medullary stenosis-bone malignancy syndrome	ENSEMBL:ENSG00000099810	methylthioadenosine phosphorylase
+ORPHANET:85179	Infantile osteopetrosis with neuroaxonal dysplasia	ENSEMBL:ENSG00000081087	osteoclastogenesis associated transmembrane protein 1
+ORPHANET:85172	Microcephalic osteodysplastic dysplasia, Saul-Wilson type	ENSEMBL:ENSG00000103051	component of oligomeric golgi complex 4
+ORPHANET:85169	Familial digital arthropathy-brachydactyly	ENSEMBL:ENSG00000111199	transient receptor potential cation channel subfamily V member 4
+ORPHANET:85167	Spondylometaphyseal dysplasia-cone-rod dystrophy syndrome	ENSEMBL:ENSG00000161217	phosphate cytidylyltransferase 1A, choline
+ORPHANET:85166	Platyspondylic dysplasia, Torrance type	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:85165	Severe achondroplasia-developmental delay-acanthosis nigricans syndrome	ENSEMBL:ENSG00000068078	fibroblast growth factor receptor 3
+ORPHANET:603689	KLHL7-related Bohring-Opitz-like syndrome	ENSEMBL:ENSG00000122550	kelch like family member 7
+ORPHANET:603684	KLHL7-related Bohring-Opitz-like/Cold-induced sweating-like overlap syndrome	ENSEMBL:ENSG00000122550	kelch like family member 7
+ORPHANET:603694	KLHL7-related cold-induced sweating-like syndrome	ENSEMBL:ENSG00000122550	kelch like family member 7
+ORPHANET:610573	CLCN6-related childhood-onset progressive neurodegeneration-peripheral neuropathy syndrome	ENSEMBL:ENSG00000011021	chloride voltage-gated channel 6
+ORPHANET:610569	KIAA1109-related early lethal congenital brain malformations-arthrogryposis syndrome	ENSEMBL:ENSG00000138688	bridge-like lipid transfer protein family member 1
+ORPHANET:611201	Oculogastrointestinal-neurodevelopmental syndrome	ENSEMBL:ENSG00000103326	calpain 15
+ORPHANET:600668	CCNK-related neurodevelopmental disorder-severe intellectual disability-facial dysmorphism syndrome	ENSEMBL:ENSG00000090061	cyclin K
+ORPHANET:600663	NRXN1-related severe neurodevelopmental disorder-motor stereotypies-chronic constipation-sleep-wake cycle disturbance	ENSEMBL:ENSG00000179915	neurexin 1
+ORPHANET:97249	Pontocerebellar hypoplasia type 3	ENSEMBL:ENSG00000186472	piccolo presynaptic cytomatrix protein
+ORPHANET:97297	Bohring-Opitz syndrome	ENSEMBL:ENSG00000171456	ASXL transcriptional regulator 1
+ORPHANET:97346	ADan amyloidosis	ENSEMBL:ENSG00000136156	integral membrane protein 2B
+ORPHANET:97345	ABri amyloidosis	ENSEMBL:ENSG00000136156	integral membrane protein 2B
+ORPHANET:97363	Unilateral multicystic dysplastic kidney	ENSEMBL:ENSG00000275410	HNF1 homeobox B
+ORPHANET:97364	Bilateral multicystic dysplastic kidney	ENSEMBL:ENSG00000275410	HNF1 homeobox B
+ORPHANET:97548	Right sided atrial isomerism	ENSEMBL:ENSG00000130283	growth differentiation factor 1
+ORPHANET:96182	Silver-Russell syndrome due to maternal uniparental disomy of chromosome 7	ENSEMBL:ENSG00000106070	growth factor receptor bound protein 10
+ORPHANET:96266	Leydig cell hypoplasia due to partial LH resistance	ENSEMBL:ENSG00000138039	luteinizing hormone/choriogonadotropin receptor
+ORPHANET:96265	Leydig cell hypoplasia due to complete LH resistance	ENSEMBL:ENSG00000138039	luteinizing hormone/choriogonadotropin receptor
+ORPHANET:97234	Glycogen storage disease due to phosphoglycerate mutase deficiency	ENSEMBL:ENSG00000164708	phosphoglycerate mutase 2
+ORPHANET:97238	Rippling muscle disease	ENSEMBL:ENSG00000182533	caveolin 3
+ORPHANET:97239	Reducing body myopathy	ENSEMBL:ENSG00000022267	four and a half LIM domains 1
+ORPHANET:97240	Zebra body myopathy	ENSEMBL:ENSG00000143632	actin alpha 1, skeletal muscle
+ORPHANET:97685	17q11 microdeletion syndrome	ENSEMBL:ENSG00000196712	neurofibromin 1
+ORPHANET:95702	X-linked adrenal hypoplasia congenita	ENSEMBL:ENSG00000169297	nuclear receptor subfamily 0 group B member 1
+ORPHANET:95699	Congenital adrenal hyperplasia due to cytochrome P450 oxidoreductase deficiency	ENSEMBL:ENSG00000127948	cytochrome p450 oxidoreductase
+ORPHANET:95698	NON RARE IN EUROPE: Non-classic congenital adrenal hyperplasia due to 21-hydroxylase deficiency	ENSEMBL:ENSG00000231852	cytochrome P450 family 21 subfamily A member 2
+ORPHANET:95433	Autosomal recessive spinocerebellar ataxia-blindness-deafness syndrome	ENSEMBL:ENSG00000124587	peroxisomal biogenesis factor 6
+ORPHANET:95232	Lissencephaly due to LIS1 mutation	ENSEMBL:ENSG00000007168	platelet activating factor acetylhydrolase 1b regulatory subunit 1
+ORPHANET:95159	Hepatoerythropoietic porphyria	ENSEMBL:ENSG00000126088	uroporphyrinogen decarboxylase
+ORPHANET:95428	COG8-CDG	ENSEMBL:ENSG00000213380	component of oligomeric golgi complex 8
+ORPHANET:94122	Cerebellar ataxia, Cayman type	ENSEMBL:ENSG00000167654	ATCAY kinesin light chain interacting caytaxin
+ORPHANET:94124	Spinocerebellar ataxia with axonal neuropathy type 1	ENSEMBL:ENSG00000042088	tyrosyl-DNA phosphodiesterase 1
+ORPHANET:94125	Recessive mitochondrial ataxia syndrome	ENSEMBL:ENSG00000140521	DNA polymerase gamma, catalytic subunit
+ORPHANET:94147	Spinocerebellar ataxia type 7	ENSEMBL:ENSG00000163635	ataxin 7
+ORPHANET:94150	Anonychia congenita totalis	ENSEMBL:ENSG00000101282	R-spondin 4
+ORPHANET:94065	15q24 microdeletion syndrome	ENSEMBL:ENSG00000169375	SIN3 transcription regulator family member A
+ORPHANET:94068	Spondyloepiphyseal dysplasia congenita	ENSEMBL:ENSG00000139219	collagen type II alpha 1 chain
+ORPHANET:94083	Partington syndrome	ENSEMBL:ENSG00000004848	aristaless related homeobox
+ORPHANET:96147	Kleefstra syndrome due to 9q34 microdeletion	ENSEMBL:ENSG00000181090	euchromatic histone lysine methyltransferase 1
+ORPHANET:597623	IRF2BPL-related regressive neurodevelopmental disorder-dystonia-seizures syndrome	ENSEMBL:ENSG00000119669	interferon regulatory factor 2 binding protein like
+ORPHANET:597733	Oculocutaneous albinism type 8	ENSEMBL:ENSG00000080166	dopachrome tautomerase
+ORPHANET:597939	Euthyroid dysprealbuminemic hyperthyroxinemia	ENSEMBL:ENSG00000118271	transthyretin
+ORPHANET:597874	MTHFS-related developmental delay-microcephaly-short stature-epilepsy syndrome	ENSEMBL:ENSG00000136371	methenyltetrahydrofolate synthetase
+ORPHANET:93562	AFib amyloidosis	ENSEMBL:ENSG00000171560	fibrinogen alpha chain
+ORPHANET:598603	Facial dysmorphism-hypertrichosis-epilepsy-intellectual disability/developmental delay-gingival overgrowth syndrome	ENSEMBL:ENSG00000182450	potassium two pore domain channel subfamily K member 4
+ORPHANET:93560	AApoAI amyloidosis	ENSEMBL:ENSG00000118137	apolipoprotein A1
+ORPHANET:93561	ALys amyloidosis	ENSEMBL:ENSG00000090382	lysozyme
+ORPHANET:93474	Scheie syndrome	ENSEMBL:ENSG00000127415	alpha-L-iduronidase
+ORPHANET:93476	Hurler-Scheie syndrome	ENSEMBL:ENSG00000127415	alpha-L-iduronidase
+ORPHANET:93473	Hurler syndrome	ENSEMBL:ENSG00000127415	alpha-L-iduronidase
+ORPHANET:93399	Juvenile sialidosis type 2	ENSEMBL:ENSG00000204386	neuraminidase 1
+ORPHANET:93400	Congenital sialidosis type 2	ENSEMBL:ENSG00000204386	neuraminidase 1
+ORPHANET:599373	STXBP1-related encephalopathy	ENSEMBL:ENSG00000136854	syntaxin binding protein 1
+ORPHANET:599376	Hypomyelination of early myelinating structures	ENSEMBL:ENSG00000123560	proteolipid protein 1
+ORPHANET:93404	Syndactyly type 3	ENSEMBL:ENSG00000152661	gap junction protein alpha 1
+ORPHANET:93406	Syndactyly type 5	ENSEMBL:ENSG00000128714	homeobox D13
+ORPHANET:93409	Brachydactyly-syndactyly, Zhao type	ENSEMBL:ENSG00000128714	homeobox D13
+ORPHANET:93360	Spondyloepimetaphyseal dysplasia with multiple dislocations	ENSEMBL:ENSG00000079616	kinesin family member 22
+ORPHANET:93358	Spondyloepimetaphyseal dysplasia-short limb-abnormal calcification syndrome	ENSEMBL:ENSG00000162733	discoidin domain receptor tyrosine kinase 2
+ORPHANET:93357	SPONASTRIME dysplasia	ENSEMBL:ENSG00000160949	tonsoku like, DNA repair protein
+ORPHANET:599082	CHD3-related developmental delay-speech delay-intellectual disability-abnormalities of vision-facial dysmorphism syndrome	ENSEMBL:ENSG00000170004	chromodomain helicase DNA binding protein 3
+ORPHANET:93372	Familial hypocalciuric hypercalcemia type 1	ENSEMBL:ENSG00000036828	calcium sensing receptor
+ORPHANET:93385	NON RARE IN EUROPE: Brachydactyly type D	ENSEMBL:ENSG00000128714	homeobox D13
+ORPHANET:93932	FG syndrome type 1	ENSEMBL:ENSG00000184634	mediator complex subunit 12
+ORPHANET:93952	X-linked intellectual disability, Hedera type	ENSEMBL:ENSG00000182220	ATPase H+ transporting accessory protein 2
+ORPHANET:595109	Atypical Timothy syndrome	ENSEMBL:ENSG00000151067	calcium voltage-gated channel subunit alpha1 C
+ORPHANET:93950	X-linked intellectual disability, Sutherland-Haan type	ENSEMBL:ENSG00000102103	polyglutamine binding protein 1
+ORPHANET:595098	Timothy syndrome type 1	ENSEMBL:ENSG00000151067	calcium voltage-gated channel subunit alpha1 C
+ORPHANET:93947	X-linked intellectual disability, Golabi-Ito-Hall type	ENSEMBL:ENSG00000102103	polyglutamine binding protein 1
+ORPHANET:595105	Timothy syndrome type 2	ENSEMBL:ENSG00000151067	calcium voltage-gated channel subunit alpha1 C
+ORPHANET:93946	Hamel cerebro-palato-cardiac syndrome	ENSEMBL:ENSG00000102103	polyglutamine binding protein 1
+ORPHANET:93945	X-linked intellectual disability, Porteous type	ENSEMBL:ENSG00000102103	polyglutamine binding protein 1
+ORPHANET:93622	Dent disease type 1	ENSEMBL:ENSG00000171365	chloride voltage-gated channel 5
+ORPHANET:93623	Dent disease type 2	ENSEMBL:ENSG00000122126	OCRL inositol polyphosphate-5-phosphatase
+ORPHANET:93598	Primary hyperoxaluria type 1	ENSEMBL:ENSG00000172482	alanine--glyoxylate aminotransferase
+ORPHANET:596008	Antley-Bixler syndrome without genital anomaly or disorder of steroidogenesis	ENSEMBL:ENSG00000066468	fibroblast growth factor receptor 2
+ORPHANET:93583	Congenital thrombotic thrombocytopenic purpura	ENSEMBL:ENSG00000160323	ADAM metallopeptidase with thrombospondin type 1 motif 13
+ORPHANET:93610	Distal renal tubular acidosis with anemia	ENSEMBL:ENSG00000004939	solute carrier family 4 member 1 (Diego blood group)
+ORPHANET:93608	Autosomal dominant distal renal tubular acidosis	ENSEMBL:ENSG00000004939	solute carrier family 4 member 1 (Diego blood group)
+ORPHANET:93607	Autosomal recessive proximal renal tubular acidosis	ENSEMBL:ENSG00000080493	solute carrier family 4 member 4
+ORPHANET:93613	Cystinuria type B	ENSEMBL:ENSG00000021488	solute carrier family 7 member 9
+ORPHANET:93612	Cystinuria type A	ENSEMBL:ENSG00000138079	solute carrier family 3 member 1
+ORPHANET:93602	Xanthinuria type II	ENSEMBL:ENSG00000075643	molybdenum cofactor sulfurase
+ORPHANET:93601	Xanthinuria type I	ENSEMBL:ENSG00000158125	xanthine dehydrogenase
+ORPHANET:93600	Primary hyperoxaluria type 3	ENSEMBL:ENSG00000241935	4-hydroxy-2-oxoglutarate aldolase 1
+ORPHANET:93599	Primary hyperoxaluria type 2	ENSEMBL:ENSG00000137106	glyoxylate and hydroxypyruvate reductase
+ORPHANET:93606	Nephrogenic syndrome of inappropriate antidiuresis	ENSEMBL:ENSG00000126895	arginine vasopressin receptor 2
+ORPHANET:596753	VEXAS syndrome	ENSEMBL:ENSG00000130985	ubiquitin like modifier activating enzyme 1
+ORPHANET:93605	Bartter syndrome type 3	ENSEMBL:ENSG00000184908	chloride voltage-gated channel Kb
+ORPHANET:99106	Atrial septal defect, ostium primum type	ENSEMBL:ENSG00000038295	tolloid like 1
+ORPHANET:99105	Atrial septal defect, sinus venosus type	ENSEMBL:ENSG00000164442	Cbp/p300 interacting transactivator with Glu/Asp rich carboxy-terminal domain 2
+ORPHANET:99141	Lymphedema-posterior choanal atresia syndrome	ENSEMBL:ENSG00000152104	protein tyrosine phosphatase non-receptor type 14
+ORPHANET:99657	Primary dystonia, DYT2 type	ENSEMBL:ENSG00000121905	hippocalcin
+ORPHANET:99429	Complete androgen insensitivity syndrome	ENSEMBL:ENSG00000169083	androgen receptor
+ORPHANET:99646	Metaphyseal chondromatosis with D-2-hydroxyglutaric aciduria	ENSEMBL:ENSG00000138413	isocitrate dehydrogenase (NADP(+)) 1
+ORPHANET:592574	Menke-Hennekam syndrome	ENSEMBL:ENSG00000005339	CREB binding protein
+ORPHANET:592564	GNAO1-related developmental delay-seizures-movement disorder spectrum	ENSEMBL:ENSG00000087258	G protein subunit alpha o1
+ORPHANET:592570	TRAF7-associated heart defect-digital anomalies-facial dysmorphism-motor and speech delay syndrome	ENSEMBL:ENSG00000131653	TNF receptor associated factor 7
+ORPHANET:589821	Congenital-onset Steinert myotonic dystrophy	ENSEMBL:ENSG00000104936	DM1 protein kinase
+ORPHANET:589827	Juvenile-onset Steinert myotonic dystrophy	ENSEMBL:ENSG00000104936	DM1 protein kinase
+ORPHANET:589824	Childhood-onset Steinert myotonic dystrophy	ENSEMBL:ENSG00000104936	DM1 protein kinase
+ORPHANET:589833	Late-onset Steinert myotonic dystrophy	ENSEMBL:ENSG00000104936	DM1 protein kinase
+ORPHANET:589830	Adult-onset Steinert myotonic dystrophy	ENSEMBL:ENSG00000104936	DM1 protein kinase
+ORPHANET:589905	PHIP-related behavioral problems-intellectual disability-obesity-dysmorphic features syndrome	ENSEMBL:ENSG00000146247	pleckstrin homology domain interacting protein
+ORPHANET:589856	Choanal atresia-athelia-hypothyroidism-delayed puberty-short stature syndrome	ENSEMBL:ENSG00000167548	lysine methyltransferase 2D
+ORPHANET:99749	Kostmann syndrome	ENSEMBL:ENSG00000143575	HCLS1 associated protein X-1
+ORPHANET:99734	Myotonia fluctuans	ENSEMBL:ENSG00000007314	sodium voltage-gated channel alpha subunit 4
+ORPHANET:99731	Isolated sulfite oxidase deficiency	ENSEMBL:ENSG00000139531	sulfite oxidase
+ORPHANET:99735	Myotonia permanens	ENSEMBL:ENSG00000007314	sodium voltage-gated channel alpha subunit 4
+ORPHANET:99736	Acetazolamide-responsive myotonia	ENSEMBL:ENSG00000007314	sodium voltage-gated channel alpha subunit 4
+ORPHANET:99741	King-Denborough syndrome	ENSEMBL:ENSG00000196218	ryanodine receptor 1
+ORPHANET:99742	Amish lethal microcephaly	ENSEMBL:ENSG00000125454	solute carrier family 25 member 19
+ORPHANET:98818	Landau-Kleffner syndrome	ENSEMBL:ENSG00000183454	glutamate ionotropic receptor NMDA type subunit 2A
+ORPHANET:98835	Acute undifferentiated leukemia	ENSEMBL:ENSG00000118058	lysine methyltransferase 2A
+ORPHANET:98831	Acute myeloid leukemia with 11q23 abnormalities	ENSEMBL:ENSG00000118058	lysine methyltransferase 2A
+ORPHANET:98832	Acute myeloid leukemia with minimal differentiation	ENSEMBL:ENSG00000122025	fms related receptor tyrosine kinase 3
+ORPHANET:98827	Unclassified myelodysplastic syndrome	ENSEMBL:ENSG00000179348	GATA binding protein 2
+ORPHANET:98826	Refractory anemia	ENSEMBL:ENSG00000168769	tet methylcytosine dioxygenase 2
+ORPHANET:98824	Atypical chronic myeloid leukemia	ENSEMBL:ENSG00000119535	colony stimulating factor 3 receptor
+ORPHANET:98843	Classic Hodgkin lymphoma, nodular sclerosis type	ENSEMBL:ENSG00000185909	kelch domain containing 8B
+ORPHANET:589608	Linear hypopigmentation and craniofacial asymmetry with acral, ocular and brain anomalies	ENSEMBL:ENSG00000067560	ras homolog family member A
+ORPHANET:98868	Southeast Asian ovalocytosis	ENSEMBL:ENSG00000004939	solute carrier family 4 member 1 (Diego blood group)
+ORPHANET:589618	Dystonia 28	ENSEMBL:ENSG00000272333	lysine methyltransferase 2B
+ORPHANET:589527	Spinocerebellar ataxia type 45	ENSEMBL:ENSG00000086570	FAT atypical cadherin 2
+ORPHANET:589547	GRIN2B-related developmental delay, intellectual disability and autism spectrum disorder	ENSEMBL:ENSG00000273079	glutamate ionotropic receptor NMDA type subunit 2B
+ORPHANET:589442	Short stature-skeletal dysplasia-retinal degeneration-intellectual disability-sensorineural hearing loss syndrome	ENSEMBL:ENSG00000241878	phosphatidylserine decarboxylase
+ORPHANET:589435	Spondylometaphyseal dysplasia-corneal dystrophy syndrome	ENSEMBL:ENSG00000149782	phospholipase C beta 3
+ORPHANET:589522	Spinocerebellar ataxia type 46	ENSEMBL:ENSG00000105223	phospholipase D family member 3
+ORPHANET:589515	PUM1-associated developmental disability-ataxia-seizure syndrome	ENSEMBL:ENSG00000134644	pumilio RNA binding family member 1
+ORPHANET:98855	Autosomal recessive Emery-Dreifuss muscular dystrophy	ENSEMBL:ENSG00000160789	lamin A/C
+ORPHANET:98856	Charcot-Marie-Tooth disease type 2B1	ENSEMBL:ENSG00000160789	lamin A/C
+ORPHANET:98885	Bleeding diathesis due to glycoprotein VI deficiency	ENSEMBL:ENSG00000088053	glycoprotein VI platelet
+ORPHANET:98873	Congenital dyserythropoietic anemia type II	ENSEMBL:ENSG00000101310	SEC23 homolog B, COPII coat complex component
+ORPHANET:98895	Becker muscular dystrophy	ENSEMBL:ENSG00000198947	dystrophin
+ORPHANET:98902	Amish nemaline myopathy	ENSEMBL:ENSG00000105048	troponin T1, slow skeletal type
+ORPHANET:98912	Late-onset distal myopathy, Markesbery-Griggs type	ENSEMBL:ENSG00000122367	LIM domain binding 3
+ORPHANET:98911	Distal myotilinopathy	ENSEMBL:ENSG00000120729	myotilin
+ORPHANET:98916	Acute inflammatory demyelinating polyradiculoneuropathy	ENSEMBL:ENSG00000109099	peripheral myelin protein 22
+ORPHANET:98904	Congenital myopathy with excess of thin filaments	ENSEMBL:ENSG00000143632	actin alpha 1, skeletal muscle
+ORPHANET:98905	Congenital multicore myopathy with external ophthalmoplegia	ENSEMBL:ENSG00000196218	ryanodine receptor 1
+ORPHANET:98908	Neutral lipid storage myopathy	ENSEMBL:ENSG00000177666	patatin like phospholipase domain containing 2
+ORPHANET:98907	Neutral lipid storage disease with ichthyosis	ENSEMBL:ENSG00000011198	abhydrolase domain containing 5, lysophosphatidic acid acyltransferase
+ORPHANET:98909	Desminopathy	ENSEMBL:ENSG00000175084	desmin
+ORPHANET:98933	Multiple system atrophy, parkinsonian type	ENSEMBL:ENSG00000173085	coenzyme Q2, polyprenyltransferase
+ORPHANET:98934	Huntington disease-like 2	ENSEMBL:ENSG00000154118	junctophilin 3
+ORPHANET:98920	Spinal muscular atrophy with respiratory distress type 1	ENSEMBL:ENSG00000132740	immunoglobulin mu DNA binding protein 2
+ORPHANET:98949	Complete cryptophthalmia	ENSEMBL:ENSG00000150893	FRAS1 related extracellular matrix 2
+ORPHANET:98957	Gelatinous drop-like corneal dystrophy	ENSEMBL:ENSG00000184292	tumor associated calcium signal transducer 2
+ORPHANET:98956	Epithelial basement membrane dystrophy	ENSEMBL:ENSG00000120708	transforming growth factor beta induced
+ORPHANET:98964	Lattice corneal dystrophy type I	ENSEMBL:ENSG00000120708	transforming growth factor beta induced
+ORPHANET:98963	Granular corneal dystrophy type II	ENSEMBL:ENSG00000120708	transforming growth factor beta induced
+ORPHANET:98962	Granular corneal dystrophy type I	ENSEMBL:ENSG00000120708	transforming growth factor beta induced
+ORPHANET:98961	Reis-Bücklers corneal dystrophy	ENSEMBL:ENSG00000120708	transforming growth factor beta induced
+ORPHANET:98960	Thiel-Behnke corneal dystrophy	ENSEMBL:ENSG00000120708	transforming growth factor beta induced
+ORPHANET:98967	Schnyder corneal dystrophy	ENSEMBL:ENSG00000120942	UbiA prenyltransferase domain containing 1
+ORPHANET:98969	Macular corneal dystrophy	ENSEMBL:ENSG00000183196	carbohydrate sulfotransferase 6
+ORPHANET:98970	Fleck corneal dystrophy	ENSEMBL:ENSG00000115020	phosphoinositide kinase, FYVE-type zinc finger containing
+ORPHANET:98975	Congenital hereditary endothelial dystrophy type I	ENSEMBL:ENSG00000125850	ovo like zinc finger 2
+ORPHANET:98990	Coralliform cataract	ENSEMBL:ENSG00000118231	crystallin gamma D
+ORPHANET:99002	Reticular dystrophy of the retinal pigment epithelium	ENSEMBL:ENSG00000136144	RCC1 and BTB domain containing protein 1
+ORPHANET:99003	Multifocal pattern dystrophy simulating fundus flavimaculatus	ENSEMBL:ENSG00000112619	peripherin 2
+ORPHANET:99013	Spastic paraplegia type 7	ENSEMBL:ENSG00000197912	SPG7 matrix AAA peptidase subunit, paraplegin
+ORPHANET:99014	X-linked Charcot-Marie-Tooth disease type 5	ENSEMBL:ENSG00000147224	phosphoribosyl pyrophosphate synthetase 1
+ORPHANET:99015	Spastic paraplegia type 2	ENSEMBL:ENSG00000123560	proteolipid protein 1
+ORPHANET:585918	B-lymphoblastic leukemia/lymphoma with t(v;11q23.3)	ENSEMBL:ENSG00000118058	lysine methyltransferase 2A
+ORPHANET:585929	B-lymphoblastic leukemia/lymphoma with t(12;21)(p13.2;q22.1)	ENSEMBL:ENSG00000139083	ETS variant transcription factor 6
+ORPHANET:99027	Adult-onset autosomal dominant leukodystrophy	ENSEMBL:ENSG00000113368	lamin B1
+ORPHANET:99042	Congenitally uncorrected transposition of the great arteries with coarctation	ENSEMBL:ENSG00000136698	cripto, FRL-1, cryptic family 1
+ORPHANET:583602	Neu-laxova syndrome due to phosphoserine aminotransferase deficiency	ENSEMBL:ENSG00000135069	phosphoserine aminotransferase 1
+ORPHANET:583607	Neu-laxova syndrome due to 3-phosphoglycerate dehydrogenase deficiency	ENSEMBL:ENSG00000092621	phosphoglycerate dehydrogenase
+ORPHANET:98795	Angelman syndrome due to paternal uniparental disomy of chromosome 15	ENSEMBL:ENSG00000114062	ubiquitin protein ligase E3A
+ORPHANET:98806	Primary dystonia, DYT6 type	ENSEMBL:ENSG00000131931	THAP domain containing 1
+ORPHANET:98805	Primary dystonia, DYT4 type	ENSEMBL:ENSG00000104833	tubulin beta 4A class IVa
+ORPHANET:98764	Spinocerebellar ataxia type 27	ENSEMBL:ENSG00000102466	fibroblast growth factor 14
+ORPHANET:98763	Spinocerebellar ataxia type 14	ENSEMBL:ENSG00000126583	protein kinase C gamma
+ORPHANET:98766	Spinocerebellar ataxia type 5	ENSEMBL:ENSG00000173898	spectrin beta, non-erythrocytic 2
+ORPHANET:98765	Spinocerebellar ataxia type 4	ENSEMBL:ENSG00000196155	pleckstrin homology and RhoGEF domain containing G4
+ORPHANET:98759	Spinocerebellar ataxia type 17	ENSEMBL:ENSG00000112592	TATA-box binding protein
+ORPHANET:98762	Spinocerebellar ataxia type 12	ENSEMBL:ENSG00000156475	protein phosphatase 2 regulatory subunit Bbeta
+ORPHANET:98761	Spinocerebellar ataxia type 10	ENSEMBL:ENSG00000130638	ataxin 10
+ORPHANET:98772	Spinocerebellar ataxia type 19/22	ENSEMBL:ENSG00000171385	potassium voltage-gated channel subfamily D member 3
+ORPHANET:98771	Spinocerebellar ataxia type 18	ENSEMBL:ENSG00000006652	interferon related developmental regulator 1
+ORPHANET:98773	Spinocerebellar ataxia type 21	ENSEMBL:ENSG00000205090	transmembrane protein 240
+ORPHANET:98768	Spinocerebellar ataxia type 13	ENSEMBL:ENSG00000131398	potassium voltage-gated channel subfamily C member 3
+ORPHANET:98767	Spinocerebellar ataxia type 11	ENSEMBL:ENSG00000128881	tau tubulin kinase 2
+ORPHANET:98769	Spinocerebellar ataxia type 15/16	ENSEMBL:ENSG00000150995	inositol 1,4,5-trisphosphate receptor type 1
+ORPHANET:580940	QRICH1-related intellectual disability-chondrodysplasia syndrome	ENSEMBL:ENSG00000198218	glutamine rich 1
+ORPHANET:580933	Lethal brain and heart developmental defects	ENSEMBL:ENSG00000077463	sirtuin 6
+ORPHANET:98755	Spinocerebellar ataxia type 1	ENSEMBL:ENSG00000124788	ataxin 1
+ORPHANET:98756	Spinocerebellar ataxia type 2	ENSEMBL:ENSG00000204842	ataxin 2
+ORPHANET:98758	Spinocerebellar ataxia type 6	ENSEMBL:ENSG00000141837	calcium voltage-gated channel subunit alpha1 A
+ORPHANET:581271	Cramp-fasciculation syndrome	ENSEMBL:ENSG00000104321	transient receptor potential cation channel subfamily A member 1
+ORPHANET:576232	Partial atrioventricular septal defect with ventricular hypoplasia	ENSEMBL:ENSG00000136574	GATA binding protein 4
+ORPHANET:576235	Partial atrioventricular septal defect without ventricular hypoplasia	ENSEMBL:ENSG00000163703	cysteine rich with EGF like domains 1
+ORPHANET:576227	Complete atrioventricular septal defect without ventricular hypoplasia	ENSEMBL:ENSG00000081189	myocyte enhancer factor 2C
+ORPHANET:575553	Cathepsin A-related arteriopathy-strokes-leukoencephalopathy	ENSEMBL:ENSG00000064601	cathepsin A
+ORPHANET:576349	NLRC4-related familial cold autoinflammatory syndrome	ENSEMBL:ENSG00000091106	NLR family CARD domain containing 4
+ORPHANET:576283	SATB2-associated syndrome due to a pathogenic variant	ENSEMBL:ENSG00000119042	SATB homeobox 2
+ORPHANET:574957	Autosomal recessive mendelian susceptibility to mycobacterial diseases due to partial JAK1 deficiency	ENSEMBL:ENSG00000162434	Janus kinase 1
+ORPHANET:574918	Predisposition to severe viral infection due to IRF7 deficiency	ENSEMBL:ENSG00000185507	interferon regulatory factor 7
+ORPHANET:572385	Brachydactyly type B1	ENSEMBL:ENSG00000169071	receptor tyrosine kinase like orphan receptor 2
+ORPHANET:572361	Blepharophimosis-ptosis-epicanthus inversus syndrome type 2	ENSEMBL:ENSG00000183770	forkhead box L2
+ORPHANET:572428	Infantile-onset pulmonary alveolar proteinosis-hypogammaglobulinemia	ENSEMBL:ENSG00000089127	2'-5'-oligoadenylate synthetase 1
+ORPHANET:572543	RFVT2-related riboflavin transporter deficiency	ENSEMBL:ENSG00000185803	solute carrier family 52 member 2
+ORPHANET:572550	RFVT3-related riboflavin transporter deficiency	ENSEMBL:ENSG00000101276	solute carrier family 52 member 3
+ORPHANET:572773	Microcephaly-short stature-limb abnormalities syndrome	ENSEMBL:ENSG00000159147	DNA replication fork stabilization factor DONSON
+ORPHANET:572798	WARS2-related combined oxidative phosphorylation defect	ENSEMBL:ENSG00000116874	tryptophanyl tRNA synthetase 2, mitochondrial
+ORPHANET:572768	Microcephaly-micromelia syndrome	ENSEMBL:ENSG00000159147	DNA replication fork stabilization factor DONSON
+ORPHANET:572333	Blepharophimosis-ptosis-epicanthus inversus syndrome plus	ENSEMBL:ENSG00000183770	forkhead box L2
+ORPHANET:572354	Blepharophimosis-ptosis-epicanthus inversus syndrome type 1	ENSEMBL:ENSG00000183770	forkhead box L2
+ORPHANET:570491	QRSL1-related combined oxidative phosphorylation defect	ENSEMBL:ENSG00000130348	glutaminyl-tRNA amidotransferase subunit QRSL1
+ORPHANET:570422	Galactose mutarotase deficiency	ENSEMBL:ENSG00000143891	galactose mutarotase
+ORPHANET:570371	Bartter syndrome type 5	ENSEMBL:ENSG00000102316	MAGE family member D2
+ORPHANET:104077	Myopathic intestinal pseudoobstruction	ENSEMBL:ENSG00000163017	actin gamma 2, smooth muscle
+ORPHANET:103909	Trehalase deficiency	ENSEMBL:ENSG00000118094	trehalase
+ORPHANET:101112	Spinocerebellar ataxia type 26	ENSEMBL:ENSG00000167658	eukaryotic translation elongation factor 2
+ORPHANET:101109	Spinocerebellar ataxia type 28	ENSEMBL:ENSG00000141385	AFG3 like matrix AAA peptidase subunit 2
+ORPHANET:101108	Spinocerebellar ataxia type 23	ENSEMBL:ENSG00000101327	prodynorphin
+ORPHANET:101085	Charcot-Marie-Tooth disease type 1F	ENSEMBL:ENSG00000277586	neurofilament light chain
+ORPHANET:101088	X-linked hyper-IgM syndrome	ENSEMBL:ENSG00000102245	CD40 ligand
+ORPHANET:101081	Charcot-Marie-Tooth disease type 1A	ENSEMBL:ENSG00000109099	peripheral myelin protein 22
+ORPHANET:101082	Charcot-Marie-Tooth disease type 1B	ENSEMBL:ENSG00000158887	myelin protein zero
+ORPHANET:101083	Charcot-Marie-Tooth disease type 1C	ENSEMBL:ENSG00000189067	lipopolysaccharide induced TNF factor
+ORPHANET:101084	Charcot-Marie-Tooth disease type 1D	ENSEMBL:ENSG00000122877	early growth response 2
+ORPHANET:101078	X-linked Charcot-Marie-Tooth disease type 4	ENSEMBL:ENSG00000156709	apoptosis inducing factor mitochondria associated 1
+ORPHANET:101075	X-linked Charcot-Marie-Tooth disease type 1	ENSEMBL:ENSG00000169562	gap junction protein beta 1
+ORPHANET:101102	Charcot-Marie-Tooth disease type 2H	ENSEMBL:ENSG00000104381	ganglioside induced differentiation associated protein 1
+ORPHANET:101101	Charcot-Marie-Tooth disease type 2B2	ENSEMBL:ENSG00000039650	polynucleotide kinase 3'-phosphatase
+ORPHANET:101097	Autosomal recessive Charcot-Marie-Tooth disease with hoarseness	ENSEMBL:ENSG00000104381	ganglioside induced differentiation associated protein 1
+ORPHANET:101090	Hyper-IgM syndrome type 3	ENSEMBL:ENSG00000101017	CD40 molecule
+ORPHANET:101089	Hyper-IgM syndrome type 2	ENSEMBL:ENSG00000111732	activation induced cytidine deaminase
+ORPHANET:101092	Hyper-IgM syndrome type 5	ENSEMBL:ENSG00000076248	uracil DNA glycosylase
+ORPHANET:101049	Familial hypocalciuric hypercalcemia type 2	ENSEMBL:ENSG00000088256	G protein subunit alpha 11
+ORPHANET:101050	Familial hypocalciuric hypercalcemia type 3	ENSEMBL:ENSG00000042753	adaptor related protein complex 2 subunit sigma 1
+ORPHANET:101068	Congenital stromal corneal dystrophy	ENSEMBL:ENSG00000011465	decorin
+ORPHANET:101010	Autosomal spastic paraplegia type 30	ENSEMBL:ENSG00000130294	kinesin family member 1A
+ORPHANET:101011	Autosomal dominant spastic paraplegia type 31	ENSEMBL:ENSG00000068615	receptor accessory protein 1
+ORPHANET:101039	Female restricted epilepsy with intellectual disability	ENSEMBL:ENSG00000165194	protocadherin 19
+ORPHANET:101028	Transaldolase deficiency	ENSEMBL:ENSG00000177156	transaldolase 1
+ORPHANET:100984	Autosomal dominant spastic paraplegia type 3	ENSEMBL:ENSG00000198513	atlastin GTPase 1
+ORPHANET:100991	Autosomal dominant spastic paraplegia type 10	ENSEMBL:ENSG00000155980	kinesin family member 5A
+ORPHANET:100989	Autosomal dominant spastic paraplegia type 8	ENSEMBL:ENSG00000164961	WASH complex subunit 5
+ORPHANET:100988	Autosomal dominant spastic paraplegia type 6	ENSEMBL:ENSG00000170113	NIPA magnesium transporter 1
+ORPHANET:100986	Autosomal recessive spastic paraplegia type 5A	ENSEMBL:ENSG00000172817	cytochrome P450 family 7 subfamily B member 1
+ORPHANET:100985	Autosomal dominant spastic paraplegia type 4	ENSEMBL:ENSG00000021574	spastin
+ORPHANET:101000	Autosomal recessive spastic paraplegia type 20	ENSEMBL:ENSG00000133104	spartin
+ORPHANET:100998	Autosomal dominant spastic paraplegia type 17	ENSEMBL:ENSG00000168000	BSCL2 lipid droplet biogenesis associated, seipin
+ORPHANET:100996	Autosomal recessive spastic paraplegia type 15	ENSEMBL:ENSG00000072121	zinc finger FYVE-type containing 26
+ORPHANET:100994	Autosomal dominant spastic paraplegia type 13	ENSEMBL:ENSG00000144381	heat shock protein family D (Hsp60) member 1
+ORPHANET:101008	Autosomal recessive spastic paraplegia type 28	ENSEMBL:ENSG00000100523	DDHD domain containing 1
+ORPHANET:101006	Autosomal recessive spastic paraplegia type 26	ENSEMBL:ENSG00000135454	beta-1,4-N-acetyl-galactosaminyltransferase 1
+ORPHANET:101001	Autosomal recessive spastic paraplegia type 21	ENSEMBL:ENSG00000090487	SPG21 abhydrolase domain containing, maspardin
+ORPHANET:100093	Carcinoid syndrome	ENSEMBL:ENSG00000204370	succinate dehydrogenase complex subunit D
+ORPHANET:100924	Porphyria due to ALA dehydratase deficiency	ENSEMBL:ENSG00000148218	aminolevulinate dehydratase
+ORPHANET:100974	FRAXF syndrome	ENSEMBL:ENSG00000269556	transmembrane protein 185A
+ORPHANET:100976	Bathing suit ichthyosis	ENSEMBL:ENSG00000092295	transglutaminase 1
+ORPHANET:100054	F12-related hereditary angioedema with normal C1Inh	ENSEMBL:ENSG00000131187	coagulation factor XII
+ORPHANET:100051	Hereditary angioedema type 2	ENSEMBL:ENSG00000149131	serpin family G member 1
+ORPHANET:100057	Renin-angiotensin-aldosterone system-blocker-induced angioedema	ENSEMBL:ENSG00000122121	X-prolyl aminopeptidase 2
+ORPHANET:100020	Refractory anemia with excess blasts type 2	ENSEMBL:ENSG00000168769	tet methylcytosine dioxygenase 2
+ORPHANET:100019	Refractory anemia with excess blasts type 1	ENSEMBL:ENSG00000168769	tet methylcytosine dioxygenase 2
+ORPHANET:100034	Hypomaturation-hypoplastic amelogenesis imperfecta with taurodontism	ENSEMBL:ENSG00000064195	distal-less homeobox 3
+ORPHANET:100044	Autosomal dominant intermediate Charcot-Marie-Tooth disease type B	ENSEMBL:ENSG00000079805	dynamin 2
+ORPHANET:100045	Autosomal dominant intermediate Charcot-Marie-Tooth disease type C	ENSEMBL:ENSG00000134684	tyrosyl-tRNA synthetase 1
+ORPHANET:100046	Autosomal dominant intermediate Charcot-Marie-Tooth disease type D	ENSEMBL:ENSG00000158887	myelin protein zero
+ORPHANET:100050	Hereditary angioedema type 1	ENSEMBL:ENSG00000149131	serpin family G member 1
+ORPHANET:100008	ACys amyloidosis	ENSEMBL:ENSG00000101439	cystatin C
+ORPHANET:100006	ABeta amyloidosis, Dutch type	ENSEMBL:ENSG00000142192	amyloid beta precursor protein
+ORPHANET:99989	Intermediate DEND syndrome	ENSEMBL:ENSG00000187486	potassium inwardly rectifying channel subfamily J member 11
+ORPHANET:99966	Atypical teratoid rhabdoid tumor	ENSEMBL:ENSG00000099956	SWI/SNF related, matrix associated, actin dependent regulator of chromatin, subfamily b, member 1
+ORPHANET:99961	Benign recurrent intrahepatic cholestasis type 2	ENSEMBL:ENSG00000073734	ATP binding cassette subfamily B member 11
+ORPHANET:99960	Benign recurrent intrahepatic cholestasis type 1	ENSEMBL:ENSG00000081923	ATPase phospholipid transporting 8B1
+ORPHANET:99955	Charcot-Marie-Tooth disease type 4B1	ENSEMBL:ENSG00000087053	myotubularin related protein 2
+ORPHANET:99956	Charcot-Marie-Tooth disease type 4B2	ENSEMBL:ENSG00000133812	SET binding factor 2
+ORPHANET:99948	Charcot-Marie-Tooth disease type 4A	ENSEMBL:ENSG00000104381	ganglioside induced differentiation associated protein 1
+ORPHANET:99947	Autosomal dominant Charcot-Marie-Tooth disease type 2A2	ENSEMBL:ENSG00000116688	mitofusin 2
+ORPHANET:99950	Charcot-Marie-Tooth disease type 4D	ENSEMBL:ENSG00000104419	N-myc downstream regulated 1
+ORPHANET:99949	Charcot-Marie-Tooth disease type 4C	ENSEMBL:ENSG00000169247	SH3 domain and tetratricopeptide repeats 2
+ORPHANET:99952	Charcot-Marie-Tooth disease type 4F	ENSEMBL:ENSG00000105227	periaxin
+ORPHANET:99951	Charcot-Marie-Tooth disease type 4E	ENSEMBL:ENSG00000122877	early growth response 2
+ORPHANET:99954	Charcot-Marie-Tooth disease type 4H	ENSEMBL:ENSG00000139132	FYVE, RhoGEF and PH domain containing 4
+ORPHANET:99953	Charcot-Marie-Tooth disease type 4G	ENSEMBL:ENSG00000156515	hexokinase 1
+ORPHANET:99940	Autosomal dominant Charcot-Marie-Tooth disease type 2F	ENSEMBL:ENSG00000106211	heat shock protein family B (small) member 1
+ORPHANET:99939	Autosomal dominant Charcot-Marie-Tooth disease type 2E	ENSEMBL:ENSG00000277586	neurofilament light chain
+ORPHANET:99942	Autosomal dominant Charcot-Marie-Tooth disease type 2I	ENSEMBL:ENSG00000158887	myelin protein zero
+ORPHANET:99944	Autosomal dominant Charcot-Marie-Tooth disease type 2K	ENSEMBL:ENSG00000104381	ganglioside induced differentiation associated protein 1
+ORPHANET:99943	Autosomal dominant Charcot-Marie-Tooth disease type 2J	ENSEMBL:ENSG00000158887	myelin protein zero
+ORPHANET:99946	Autosomal dominant Charcot-Marie-Tooth disease type 2A1	ENSEMBL:ENSG00000054523	kinesin family member 1B
+ORPHANET:99945	Autosomal dominant Charcot-Marie-Tooth disease type 2L	ENSEMBL:ENSG00000152137	heat shock protein family B (small) member 8
+ORPHANET:99936	Autosomal dominant Charcot-Marie-Tooth disease type 2B	ENSEMBL:ENSG00000075785	RAB7A, member RAS oncogene family
+ORPHANET:99937	Autosomal dominant Charcot-Marie-Tooth disease type 2C	ENSEMBL:ENSG00000111199	transient receptor potential cation channel subfamily V member 4
+ORPHANET:99938	Autosomal dominant Charcot-Marie-Tooth disease type 2D	ENSEMBL:ENSG00000106105	glycyl-tRNA synthetase 1
+ORPHANET:99916	Malignant Sertoli-Leydig cell tumor of the ovary	ENSEMBL:ENSG00000100697	dicer 1, ribonuclease III
+ORPHANET:99914	Gynandroblastoma	ENSEMBL:ENSG00000100697	dicer 1, ribonuclease III
+ORPHANET:99901	Acyl-CoA dehydrogenase 9 deficiency	ENSEMBL:ENSG00000177646	acyl-CoA dehydrogenase family member 9
+ORPHANET:99898	Mendelian susceptibility to mycobacterial diseases due to complete IFNgammaR1 deficiency	ENSEMBL:ENSG00000027697	interferon gamma receptor 1
+ORPHANET:99880	Hyperparathyroidism-jaw tumor syndrome	ENSEMBL:ENSG00000134371	cell division cycle 73
+ORPHANET:99887	Acute megakaryoblastic leukemia in Down syndrome	ENSEMBL:ENSG00000102145	GATA binding protein 1
+ORPHANET:99849	Glycogen storage disease due to muscle beta-enolase deficiency	ENSEMBL:ENSG00000108515	enolase 3
+ORPHANET:99843	Leukocyte adhesion deficiency type II	ENSEMBL:ENSG00000181830	solute carrier family 35 member C1
+ORPHANET:99844	Leukocyte adhesion deficiency type III	ENSEMBL:ENSG00000149781	FERM domain containing kindlin 3
+ORPHANET:99852	Ravine syndrome	ENSEMBL:ENSG00000279903	SLC7A2 intronic transcript 1
+ORPHANET:99832	Resistance to thyrotropin-releasing hormone syndrome	ENSEMBL:ENSG00000174417	thyrotropin releasing hormone receptor
+ORPHANET:99842	Leukocyte adhesion deficiency type I	ENSEMBL:ENSG00000160255	integrin subunit beta 2
+ORPHANET:99811	Neuronal intestinal pseudoobstruction	ENSEMBL:ENSG00000196924	filamin A
+ORPHANET:99818	Turcot syndrome with polyposis	ENSEMBL:ENSG00000134982	APC regulator of WNT signaling pathway
+ORPHANET:99819	Familial gestational hyperthyroidism	ENSEMBL:ENSG00000165409	thyroid stimulating hormone receptor
+ORPHANET:99807	PEHO-like syndrome	ENSEMBL:ENSG00000115355	coiled-coil domain containing 88A
+ORPHANET:99791	Dentin dysplasia type II	ENSEMBL:ENSG00000152591	dentin sialophosphoprotein
+ORPHANET:631073	Autosomal recessive spastic paraplegia type 82	ENSEMBL:ENSG00000185813	phosphate cytidylyltransferase 2, ethanolamine
+ORPHANET:631076	Autosomal recessive spastic paraplegia type 83	ENSEMBL:ENSG00000186603	4-hydroxyphenylpyruvate dioxygenase like
+ORPHANET:631079	Autosomal recessive spastic paraplegia type 84	ENSEMBL:ENSG00000241973	phosphatidylinositol 4-kinase alpha
+ORPHANET:631082	Autosomal recessive spastic paraplegia type 85	ENSEMBL:ENSG00000120925	ring finger protein 170
+ORPHANET:631068	Autosomal dominant spastic paraplegia type 80	ENSEMBL:ENSG00000165006	ubiquitin associated protein 1
+ORPHANET:631106	Spinocerebellar ataxia type 49	ENSEMBL:ENSG00000177409	sterile alpha motif domain containing 9 like
+ORPHANET:631103	Spinocerebellar ataxia type 48	ENSEMBL:ENSG00000103266	STIP1 homology and U-box containing protein 1
+ORPHANET:631095	Spinocerebellar ataxia type 44	ENSEMBL:ENSG00000152822	glutamate metabotropic receptor 1
+ORPHANET:631088	Autosomal recessive spastic paraplegia type 87	ENSEMBL:ENSG00000165548	transmembrane protein 63C
+ORPHANET:631085	Autosomal recessive spastic paraplegia type 86	ENSEMBL:ENSG00000204427	abhydrolase domain containing 16A, phospholipase
+ORPHANET:631248	Mitchell Syndrome	ENSEMBL:ENSG00000161533	acyl-CoA oxidase 1
+ORPHANET:633021	SLC12A2-related autosomal recessive neonatal-developmental delay-intellectual disability-feeding difficulty-sensorineural deafness syndrome	ENSEMBL:ENSG00000064651	solute carrier family 12 member 2
+ORPHANET:633024	SLC12A2-related autosomal dominant infantile-developmental delay-intellectual disability-sensorineural deafness syndrome	ENSEMBL:ENSG00000064651	solute carrier family 12 member 2
+ORPHANET:633004	KDM3B-related intellectual disability-facial dysmorphism-short stature syndrome	ENSEMBL:ENSG00000120733	lysine demethylase 3B
+ORPHANET:621758	Fibrosis-neurodegeneration-cerebral angiomatosis syndrome	ENSEMBL:ENSG00000196865	NHL repeat containing 2
+ORPHANET:620368	EGF-related primary hypomagnesemia with intellectual disability	ENSEMBL:ENSG00000138798	epidermal growth factor
+ORPHANET:620363	Primary hypomagnesemia-generalized seizures-intellectual disability-obesity syndrome	ENSEMBL:ENSG00000148842	cyclin and CBS domain divalent metal cation transport mediator 2
+ORPHANET:620220	Bartter syndrome type 2	ENSEMBL:ENSG00000151704	potassium inwardly rectifying channel subfamily J member 1
+ORPHANET:620158	Non-syndromic non-specific multisutural craniosynostosis	ENSEMBL:ENSG00000010361	fuzzy planar cell polarity protein
+ORPHANET:623695	MIR140-related spondyloepiphyseal dysplasia	ENSEMBL:ENSG00000208017	microRNA 140
+ORPHANET:622925	X-linked severe syndromic thoracic aortic aneurysm and dissection	ENSEMBL:ENSG00000182492	biglycan
+ORPHANET:622934	SBDS-related severe neonatal spondylometaphyseal dysplasia	ENSEMBL:ENSG00000126524	SBDS ribosome maturation factor
+ORPHANET:617919	F12-associated cold autoinflammatory syndrome	ENSEMBL:ENSG00000131187	coagulation factor XII
+ORPHANET:619941	Immune deficiency due to impaired neutrophil phagocytosis and migration	ENSEMBL:ENSG00000196588	myocardin related transcription factor A
+ORPHANET:619367	SAMD9L-associated autoinflammatory syndrome	ENSEMBL:ENSG00000177409	sterile alpha motif domain containing 9 like
+ORPHANET:619953	Familial hyperinflammatory lymphoproliferative immunodeficiency	ENSEMBL:ENSG00000123338	NCK associated protein 1 like
+ORPHANET:619948	Early-onset autoimmunity-autoinflammation-immunodeficiency syndrome	ENSEMBL:ENSG00000185338	suppressor of cytokine signaling 1
+ORPHANET:619979	Developmental delay-immunodeficiency-leukoencephalopathy-hypohomocysteinemia syndrome	ENSEMBL:ENSG00000116044	NFE2 like bZIP transcription factor 2
+ORPHANET:619972	CADINS disease	ENSEMBL:ENSG00000198286	caspase recruitment domain family member 11
+ORPHANET:619363	Neonatal-onset severe multisystemic autoinflammatory disease with increased IL18	ENSEMBL:ENSG00000070831	cell division cycle 42
+ORPHANET:619233	Hereditary persistence of fetal hemoglobin-intellectual disability syndrome	ENSEMBL:ENSG00000119866	BAF chromatin remodeling complex subunit BCL11A

--- a/config/OrphaNet/data_processing/generate_orpha_gene_disease_benchmarks.py
+++ b/config/OrphaNet/data_processing/generate_orpha_gene_disease_benchmarks.py
@@ -3,7 +3,7 @@ import requests
 import xmltodict
 
 # use this if loading data from raw xml file (up-to-date as of 2/15/2023)
-# with open('en_product6.xml') as xml_file:
+# with open('../en_product6.xml') as xml_file:
 #    data_dict = xmltodict.parse(xml_file.read())
 
 # us this if extracting from link from http://www.orphadata.org/cgi-bin/index.php
@@ -30,7 +30,7 @@ for data in data_dict['JDBOR']['DisorderList']['Disorder']:
                     x.append([orpha_code, orpha_name, gene_curie, gene_name])
                     found = True
                     break
-with open('orphanet_benchmark.tsv', 'w', newline='') as f:
+with open('../data.tsv', 'w', newline='') as f:
     writer = csv.writer(f, delimiter='\t')
     writer.writerows(x)
 

--- a/config/OrphaNet/generate_orpha_gene_disease_benchmarks.py
+++ b/config/OrphaNet/generate_orpha_gene_disease_benchmarks.py
@@ -1,0 +1,36 @@
+import csv
+import requests
+import xmltodict
+
+# use this if loading data from raw xml file (up-to-date as of 2/15/2023)
+# with open('en_product6.xml') as xml_file:
+#    data_dict = xmltodict.parse(xml_file.read())
+
+# us this if extracting from link from http://www.orphadata.org/cgi-bin/index.php
+# Note, that file name is likely to change for newer versions and will require updating
+r = requests.get('http://www.orphadata.org/data/xml/en_product6.xml')
+data_dict = xmltodict.parse(r.content)
+
+x = [['Disease_Curie', 'Disease_Name', 'Gene_Curie', 'Gene_Name']]
+for data in data_dict['JDBOR']['DisorderList']['Disorder']:
+    orpha_code = 'ORPHANET:{}'.format(data['OrphaCode'])
+    orpha_name = data['Name']['#text']
+    associations = data['DisorderGeneAssociationList']['DisorderGeneAssociation']
+    if type(associations) is not list:
+        associations = [associations]
+        for association in associations:
+            gene_name = association['Gene']['Name']['#text']
+            references = association['Gene']['ExternalReferenceList']['ExternalReference']
+            found = False
+            if type(references) is not list:
+                references = [references]
+            for reference in references:
+                if reference['Source'] == 'Ensembl':
+                    gene_curie = 'ENSEMBL:{}'.format(reference['Reference'])
+                    x.append([orpha_code, orpha_name, gene_curie, gene_name])
+                    found = True
+                    break
+with open('orphanet_benchmark.tsv', 'w', newline='') as f:
+    writer = csv.writer(f, delimiter='\t')
+    writer.writerows(x)
+

--- a/config/OrphaNet/templates/gene-to-raredisease.json
+++ b/config/OrphaNet/templates/gene-to-raredisease.json
@@ -1,0 +1,26 @@
+{
+  "message": {
+    "query_graph": {
+      "nodes": {
+        "Disease_Curie": {
+          "categories": [
+            "biolink:DiseaseOrPhenotypicFeature"
+          ]
+
+        },
+        "Gene_Curie": {
+          "ids": [],
+          "categories": [
+            "biolink:Gene"
+          ]
+        }
+      },
+      "edges": {
+        "e01": {
+          "object": "Gene_Curie",
+          "subject": "Disease_Curie"
+        }
+      }
+    }
+  }
+}

--- a/config/OrphaNet/templates/raredisease-to-gene.json
+++ b/config/OrphaNet/templates/raredisease-to-gene.json
@@ -1,0 +1,26 @@
+{
+  "message": {
+    "query_graph": {
+      "nodes": {
+        "Disease_Curie": {
+          "ids": [],
+          "categories": [
+            "biolink:DiseaseOrPhenotypicFeature"
+          ]
+
+        },
+        "Gene_Curie": {
+          "categories": [
+            "biolink:Gene"
+          ]
+        }
+      },
+      "edges": {
+        "e01": {
+          "object": "Gene_Curie",
+          "subject": "Disease_Curie"
+        }
+      }
+    }
+  }
+}

--- a/config/benchmarks.json
+++ b/config/benchmarks.json
@@ -16,5 +16,14 @@
             "source": "DrugMechDB",
             "templates": ["three_hop"]
         }
+    ],
+    "orphadata": [
+        {
+            "source": "OrphaNet",
+            "templates": [
+                "raredisease-to-gene",
+                "gene-to-raredisease"
+            ]
+        }
     ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 numpy
 requests
 tqdm
+xmltodict

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
         'matplotlib',
         'numpy',
         'requests',
-        'tqdm'
+        'tqdm',
+        'xmltodict'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Added a benchmark for OrphaNet containing rare-disease to gene edges. This includes a parser script to generate the data file from either the raw xml (en_product6.xml) or from http://www.orphadata.org/data/xml/en_product6.xml. We added a library to the setup.py and requirements.txt (xmltodict) to parse xml into python objects for ease. data.tsv includes the output benchmark edges that maps to our templates.