### PR TITLE
remove ID on Protein node for DrugMechDB template

### DIFF
--- a/config/DrugMechDB/templates/three_hop.json
+++ b/config/DrugMechDB/templates/three_hop.json
@@ -6,7 +6,6 @@
           "ids": []
         },
         "Protein": {
-          "ids": [],
           "categories": [
             "biolink:Protein"
           ]


### PR DESCRIPTION
Now that (I think) I understand the templating system a bit better, I think removing the ID on the Protein node in the DrugMechDB template would be better.  I think the goal of the benchmark would be to specify the start and end nodes (for `Drug` and `Disease`, respectively), and then see if tools retrieve the intermediate nodes (for `Protein` and `BiologicalProcess`).