### PR TITLE
Get score from result.analyses instead of result

### DIFF
--- a/benchmarks/eval.py
+++ b/benchmarks/eval.py
@@ -104,7 +104,7 @@ def evaluate_results(benchmark: str, results: Union[str, dict], k: int = 50, use
                 with open(result_path) as file:
                     results_k = sorted(
                         json.load(file).get('message', {}).get('results', []),
-                        key=lambda r: r['score'],
+                        key=lambda r: r['analyses'][0]['score'],
                         reverse=True
                     )[:k]
         elif type(results) is dict:
@@ -115,7 +115,7 @@ def evaluate_results(benchmark: str, results: Union[str, dict], k: int = 50, use
                 # Grab message from dict
                 results_k = sorted(
                     results.get(uid, {}).get('message', {}).get('results', []),
-                    key=lambda r: r['score'],
+                    key=lambda r: r['analyses'][0]['score'],
                     reverse=True
                 )[:k]
 


### PR DESCRIPTION
With TRAPI 1.4, the score for BTE has been moved to the results.analyses. Not sure how other ARAs / KPs are handling this especially if there are multiple analyses objects and scores...