### PR TITLE
update requirements and documentation for benchmark_runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,18 @@ from benchmarks_runner import run_benchmarks
 out = asyncio.run(run_benchmarks(<benchmark>, <target>))
 ```
 where benchmark is the name of a benchmark that is specified in config/benchmarks.json, and a target that is specified in config/targets.json
+
+## Sample output
+
+```
+Benchmark: GTRx
+Results Directory: /tmp/tmpaf10m9_q/GTRx/bte/2023-11-10_13-03-11
+
+                        k=1     k=5     k=10    k=20
+Precision @ k           0.0000  0.0500  0.0250  0.0125
+Recall @ k              0.0000  0.2500  0.2500  0.2500
+mAP @ k                 0.0000  0.0833  0.0833  0.0833
+Top-k Accuracy          0.0000  0.2500  0.2500  0.2500
+
+Mean Reciprocal Rank    0.08333333333333333
+```

--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ The benchmarks can be installed from pypi and used as part of the Translator-wid
 - `pip install benchmarks-runner`
 To run benchmarks:
 ```python
+import asyncio
 from benchmarks_runner import run_benchmarks
 
-run_benchmarks(<benchmark>, <target>)
+out = asyncio.run(run_benchmarks(<benchmark>, <target>))
 ```
 where benchmark is the name of a benchmark that is specified in config/benchmarks.json, and a target that is specified in config/targets.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv
 requests
 tqdm
 uvicorn
+reasoner_pydantic


### PR DESCRIPTION
on a fresh installation/environment, `reasoner_pydantic` needs to be installed

```
$ benchmarks_fetch
Traceback (most recent call last):
  File "/home/asu/env/benchmarks-pypi/bin/benchmarks_fetch", line 5, in <module>
    from benchmarks.cli.fetch import main
  File "/home/asu/Science/Benchmarks-pypi/benchmarks/cli/fetch.py", line 3, in <module>
    from benchmarks.request import fetch_results
  File "/home/asu/Science/Benchmarks-pypi/benchmarks/request.py", line 12, in <module>
    from reasoner_pydantic import Response
ModuleNotFoundError: No module named 'reasoner_pydantic'
(benchmarks-pypi) asu@LAPTOP-FKGA5D64:Benchmarks-pypi$ pip install reasoner_pydantic
Collecting reasoner_pydantic
  Downloading reasoner_pydantic-4.1.5-py3-none-any.whl.metadata (3.1 kB)
Collecting pydantic<2,>=1.8 (from reasoner_pydantic)
  Downloading pydantic-1.10.13-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (149 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 149.6/149.6 kB 4.8 MB/s eta 0:00:00
Requirement already satisfied: typing-extensions>=4.2.0 in /home/asu/env/benchmarks-pypi/lib/python3.10/site-packages (from pydantic<2,>=1.8->reasoner_pydantic) (4.8.0)
Downloading reasoner_pydantic-4.1.5-py3-none-any.whl (15 kB)
Downloading pydantic-1.10.13-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.1 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.1/3.1 MB 14.2 MB/s eta 0:00:00
Installing collected packages: pydantic, reasoner_pydantic
  Attempting uninstall: pydantic
    Found existing installation: pydantic 2.4.2
    Uninstalling pydantic-2.4.2:
      Successfully uninstalled pydantic-2.4.2
Successfully installed pydantic-1.10.13 reasoner_pydantic-4.1.5
(benchmarks-pypi) asu@LAPTOP-FKGA5D64:Benchmarks-pypi$ benchmarks_fetch
usage: benchmarks_fetch [-h] [--overwrite] [--unscored] [--n N] benchmark target results_dir
benchmarks_fetch: error: the following arguments are required: benchmark, target, results_dir
```